### PR TITLE
Determine GH Actions user photo programmatically

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,7 +49,7 @@ jobs:
         color: '#23c22e'
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
-        author_name: github-actions
+        author_name: github-actions[bot]
         author_icon: https://i.imgur.com/kUxzV44s.png
         text: Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}` *passed*.
 
@@ -65,6 +65,6 @@ jobs:
         color: '#bd2222'
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
-        author_name: github-actions
+        author_name: github-actions[bot]
         author_icon: https://i.imgur.com/kUxzV44s.png
         text: Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}` *failed*.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,6 +17,13 @@ jobs:
         echo "::set-env name=PULL_URL::$(echo https://github.com/${{ github.repository }}/pull/$pull_id)"
         echo "::set-env name=BRANCH::$(echo ${{ github.head_ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
         echo "::set-env name=BUILD_URL::$(echo https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        if [[ ${{ github.actor }} == pr-scheduler[bot] ]]; then
+          echo "::set-env name=AUTHOR_NAME::pr-scheduler[bot]"
+          echo "::set-env name=ACTOR_ICON::https://i.imgur.com/tmdeggv.png"
+        else
+          echo "::set-env name=AUTHOR_NAME::${{ github.actor }}"
+          echo "::set-env name=AUTHOR_ICON::https://github.com/${{ github.actor }}.png"
+        fi
 
     - name: Switch to Current Branch
       run: git checkout ${{ env.BRANCH }}
@@ -52,9 +59,8 @@ jobs:
         color: '#23c22e'
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
-        author_name: ${{ github.actor }}
-        author_link: https://github.com/${{ github.actor }}
-        author_icon: https://github.com/${{ github.actor }}.png
+        author_name: ${{ env.AUTHOR_NAME }}
+        author_icon: ${{ env.AUTHOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *passed*.
@@ -71,9 +77,8 @@ jobs:
         color: '#bd2222'
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
-        author_name: ${{ github.actor }}
-        author_link: https://github.com/${{ github.actor }}
-        author_icon: https://github.com/${{ github.actor }}.png
+        author_name: ${{ env.AUTHOR_NAME }}
+        author_icon: ${{ env.AUTHOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *failed*.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,11 +17,6 @@ jobs:
         echo "::set-env name=PULL_URL::$(echo https://github.com/${{ github.repository }}/pull/$pull_id)"
         echo "::set-env name=BRANCH::$(echo ${{ github.head_ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
         echo "::set-env name=BUILD_URL::$(echo https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        if [[ ${{ github.actor }} == emmasax4 ]]; then
-          echo "::set-env name=ACTOR_ICON::https://i.imgur.com/tmdeggv.png"
-        else
-          echo "::set-env name=ACTOR_ICON::https://github.com/${{ github.actor }}.png"
-        fi
 
     - name: Switch to Current Branch
       run: git checkout ${{ env.BRANCH }}
@@ -58,7 +53,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_icon: ${{ env.ACTOR_ICON }}
+        author_icon: https://github.com/${{ github.actor }}.png
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *passed*.
@@ -76,7 +71,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_icon: ${{ env.ACTOR_ICON }}
+        author_icon: https://github.com/${{ github.actor }}.png
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *failed*.

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,11 +17,9 @@ jobs:
         echo "::set-env name=PULL_URL::$(echo https://github.com/${{ github.repository }}/pull/$pull_id)"
         echo "::set-env name=BRANCH::$(echo ${{ github.head_ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
         echo "::set-env name=BUILD_URL::$(echo https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        if [[ ${{ github.actor }} == pr-scheduler[bot] ]]; then
-          echo "::set-env name=AUTHOR_NAME::pr-scheduler[bot]"
+        if [[ ${{ github.actor }} == emmasax4 ]]; then
           echo "::set-env name=ACTOR_ICON::https://i.imgur.com/tmdeggv.png"
         else
-          echo "::set-env name=AUTHOR_NAME::${{ github.actor }}"
           echo "::set-env name=AUTHOR_ICON::https://github.com/${{ github.actor }}.png"
         fi
 
@@ -59,7 +57,7 @@ jobs:
         color: '#23c22e'
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
-        author_name: ${{ env.AUTHOR_NAME }}
+        author_name: ${{ github.actor }}
         author_icon: ${{ env.AUTHOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
@@ -77,7 +75,7 @@ jobs:
         color: '#bd2222'
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
-        author_name: ${{ env.AUTHOR_NAME }}
+        author_name: ${{ github.actor }}
         author_icon: ${{ env.AUTHOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -20,7 +20,7 @@ jobs:
         if [[ ${{ github.actor }} == emmasax4 ]]; then
           echo "::set-env name=ACTOR_ICON::https://i.imgur.com/tmdeggv.png"
         else
-          echo "::set-env name=AUTHOR_ICON::https://github.com/${{ github.actor }}.png"
+          echo "::set-env name=ACTOR_ICON::https://github.com/${{ github.actor }}.png"
         fi
 
     - name: Switch to Current Branch
@@ -58,7 +58,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_icon: ${{ env.AUTHOR_ICON }}
+        author_icon: ${{ env.ACTOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *passed*.
@@ -76,7 +76,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_icon: ${{ env.AUTHOR_ICON }}
+        author_icon: ${{ env.ACTOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *failed*.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
       run: |
         echo "::set-env name=BRANCH::$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')"
         echo "::set-env name=BUILD_URL::$(echo https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+        if [[ ${{ github.actor }} == pr-scheduler[bot] ]]; then
+          echo "::set-env name=ACTOR_ICON::https://i.imgur.com/tmdeggv.png"
+        else
+          echo "::set-env name=AUTHOR_ICON::https://github.com/${{ github.actor }}.png"
+        fi
 
     - name: Switch to Current Branch
       run: git checkout ${{ env.BRANCH }}
@@ -72,8 +77,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_link: https://github.com/${{ github.actor }}
-        author_icon: https://github.com/${{ github.actor }}.png
+        author_icon: ${{ env.AUTHOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           *passed*. ${{ env.DEPLOY_MESSAGE }}.
@@ -91,8 +95,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_link: https://github.com/${{ github.actor }}
-        author_icon: https://github.com/${{ github.actor }}.png
+        author_icon: ${{ env.AUTHOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           *failed*. ${{ env.DEPLOY_MESSAGE }}.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         if [[ ${{ github.actor }} == pr-scheduler[bot] ]]; then
           echo "::set-env name=ACTOR_ICON::https://i.imgur.com/tmdeggv.png"
         else
-          echo "::set-env name=AUTHOR_ICON::https://github.com/${{ github.actor }}.png"
+          echo "::set-env name=ACTOR_ICON::https://github.com/${{ github.actor }}.png"
         fi
 
     - name: Switch to Current Branch
@@ -77,7 +77,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_icon: ${{ env.AUTHOR_ICON }}
+        author_icon: ${{ env.ACTOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           *passed*. ${{ env.DEPLOY_MESSAGE }}.
@@ -95,7 +95,7 @@ jobs:
         title: ${{ github.repository }}
         title_link: https://github.com/${{ github.repository }}
         author_name: ${{ github.actor }}
-        author_icon: ${{ env.AUTHOR_ICON }}
+        author_icon: ${{ env.ACTOR_ICON }}
         text: >-
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           *failed*. ${{ env.DEPLOY_MESSAGE }}.


### PR DESCRIPTION
## Changes
GitHub Actions should know "who" triggered the build automatically, and should be able to more intelligently look up the photo to show based on that. For crons, still just automatically use the `github-actions[bot]` bot and icon. For release, it should show as the `pr-scheduler[bot]` if applicable, and should then show that icon.

## PR Scheduler
> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 18-05-2020T17:58
>
> @prscheduler DD-MM-YYYYTHH:MM
> ```
