### PR TITLE
Fix error rendering dates

### DIFF
--- a/assets/js/external-links.js
+++ b/assets/js/external-links.js
@@ -7,7 +7,7 @@ To open an INTERNAL link in a NEW tab, write your link like this:
 */
 var links = document.getElementsByTagName('a');
 
-for(counter = 0; counter < links.length; counter++) {
+for (counter = 0; counter < links.length; counter++) {
   var link = links[counter];
 
   if (link.target == '_self') {

--- a/assets/js/show-dates.js
+++ b/assets/js/show-dates.js
@@ -21,16 +21,38 @@ var monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
 
 for (counter = 0; counter < dates.length; counter++) {
   var htmlDate = dates[counter];
-  var dateArray = htmlDate.innerHTML.trim().split(/[^0-9]/);
-  var timezone_as_digits = dateArray[dateArray.length - 1];
+  var dateArrayByDigit = htmlDate.innerHTML.trim().split(/[^0-9]/);
+  var dateArrayBySpace = htmlDate.innerHTML.split(' ');
+  var timezoneAsDigit = dateArrayBySpace[dateArrayBySpace.length - 1];
 
-  if (timezone_as_digits == "+0000") { // UTC timezone
+  if (timezoneAsDigit == "+0000") {
+    // Get the local date when it's written as in UTC timezone
     var localDate = new Date(
-      Date.UTC(dateArray[0], dateArray[1]-1, dateArray[2], dateArray[3], dateArray[4], dateArray[5])
+      Date.UTC(
+        dateArrayByDigit[0], dateArrayByDigit[1]-1, dateArrayByDigit[2],
+        dateArrayByDigit[3], dateArrayByDigit[4], dateArrayByDigit[5]
+      )
     );
   } else {
+    // Get the written date in the local timezone (which may not be written timezone)
+    var writtenDate = new Date(
+      dateArrayByDigit[0], dateArrayByDigit[1]-1, dateArrayByDigit[2],
+      dateArrayByDigit[3], dateArrayByDigit[4], dateArrayByDigit[5]
+    );
+
+    // Convert written date in local timezone to UTC timezone
+    var utcDateAsNumbers = writtenDate.getTime() - (timezoneAsDigit * 60 * 60 * 10);
+    var utcDate = new Date(utcDateAsNumbers);
+    var utcYear = utcDate.getFullYear();
+    var utcMonth = utcDate.getMonth();
+    var utcDay = utcDate.getDate();
+    var utcHour = utcDate.getHours();
+    var utcMinute = utcDate.getMinutes();
+    var utcMilliseconds = utcDate.getMilliseconds();
+
+    // Get the local date when it's written as in UTC timezone
     var localDate = new Date(
-      dateArray[0], dateArray[1]-1, dateArray[2], dateArray[3], dateArray[4], dateArray[5]
+      Date.UTC(utcYear, utcMonth, utcDay, utcHour, utcMinute, utcMilliseconds)
     );
   };
 

--- a/assets/js/show-dates.js
+++ b/assets/js/show-dates.js
@@ -4,8 +4,10 @@ and will render them in the readers' local time, instead of in UTC.
 
 An incoming date/time will be formatted like this:
   2019-12-29 03:00:00 +0000
+or like this:
+  2019-12-28 21:00:00 -0600
 
-And it will be turned into this (CST):
+And it will be turned into this (CST) if in UTC time:
   Sat Dec 28 2019 21:00:00 GMT-0600
 
 And written like this:
@@ -17,12 +19,21 @@ var monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
                   'July','August', 'September', 'October','November', 'December'
 ];
 
-for(counter = 0; counter < dates.length; counter++) {
+for (counter = 0; counter < dates.length; counter++) {
   var htmlDate = dates[counter];
   var dateArray = htmlDate.innerHTML.trim().split(/[^0-9]/);
-  var localDate = new Date(
-    Date.UTC(dateArray[0], dateArray[1]-1, dateArray[2], dateArray[3], dateArray[4], dateArray[5])
-  );
+  var timezone_as_digits = dateArray[dateArray.length - 1];
+
+  if (timezone_as_digits == "+0000") { // UTC timezone
+    var localDate = new Date(
+      Date.UTC(dateArray[0], dateArray[1]-1, dateArray[2], dateArray[3], dateArray[4], dateArray[5])
+    );
+  } else {
+    var localDate = new Date(
+      dateArray[0], dateArray[1]-1, dateArray[2], dateArray[3], dateArray[4], dateArray[5]
+    );
+  };
+
   var day = localDate.getDate();
   var year = localDate.getFullYear();
   var monthIndex = localDate.getMonth();


### PR DESCRIPTION
## Changes

There's currently a bug where the blog post SHOW page incorrectly shows the date that the blog post was published if the time it was published is close to a switch in dates. The issue is that the code previously assumed all incoming dates were UTC, so then turned all of the UTC dates into my local time (-0500). However, the dates coming from the SHOW page are not in UTC... they're in the author's written timezone. The dates from the INDEX page are UTC, so that always worked correctly.

So now, check the timezone from what's written. If it's `"+0000"`, then it's UTC, and turn that date into my local time. If it's not UTC, then do some fancier date modification:
* Turn the non-UTC date into a date object (unfortunately Javascript's date object won't allow me to directly specify which timezone it's in... that'd make it too easy, so just make it in my local time for right now—see [here](https://stackoverflow.com/questions/15141762/how-to-initialize-a-javascript-date-to-a-particular-time-zone))
* Convert that non-UTC date into UTC by multiplying its timezone (which we remember from our `if` statement earlier) by some numbers and then adding them to the time—see [here](https://stackoverflow.com/questions/1050720/adding-hours-to-javascript-date-object)
* Create a new UTC date from that (but again, like before, the date object will be written in my local timezone, but all we care about is the date, hour, minutes, etc)
* Create a new UTC date where we explicitly pass in the information from above date, but make sure to define it as UTC, which Javascript will _then_ switch to my local timezone

Uffda! Of course, I could've simplified this, but that would've broken IE and Safari (see [here](http://biostall.com/javascript-new-date-returning-nan-in-ie-or-invalid-date-in-safari/)), so I'm stuck with a long workaround. It seems to work though, so that's what matters.