### PR TITLE
Remove branch name from deploy commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         BRANCH: gh-pages
         FOLDER: _site
         CLEAN: true
-        COMMIT_MESSAGE: 'Deploy to ${{ github.repository }} on branch gh-pages'
+        COMMIT_MESSAGE: 'Deploy to ${{ github.repository }}'
         GIT_CONFIG_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         GIT_CONFIG_NAME: github-actions[bot]
 


### PR DESCRIPTION
## Changes
Remove the branch name from the release workflow GitHub commit message because it's not really needed.
