### PR TITLE
Update fonts; respace blog/lego pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/emmasax4/jekyll-feed.git
-  revision: 7f89b27bdcb21fc42831a9f143b3ab7304a9ec7e
+  revision: 95b92fc052443e90c0bd7e5403c694035f0ac647
   branch: emmasax4_feed
   specs:
     jekyll-feed (0.14.0)

--- a/_blog_posts/email-subscriptions-rss-feeds-and-feed-readers.md
+++ b/_blog_posts/email-subscriptions-rss-feeds-and-feed-readers.md
@@ -49,7 +49,7 @@ layout: none
     {% for post in site.posts limit: feed.items %}
       <item>
         {% if post.subtitle %}
-          {% assign short_title = post.title | append: " → " | append: post.subtitle %}
+          {% assign short_title = post.title | append: " — " | append: post.subtitle %}
         {% else %}
           {% assign short_title = post.title %}
         {% endif %}

--- a/_includes/blog/post.html
+++ b/_includes/blog/post.html
@@ -1,7 +1,7 @@
 {% assign post_url = post.url | downcase | replace: ".html", "" %}
 {% if post.subtitle %}
   {% if page.pagination.title == "Blog" %}
-    {% assign short_title = post.title | append: " → " | append: post.subtitle %}
+    {% assign short_title = post.title | append: " — " | append: post.subtitle %}
   {% else %}
     {% assign short_title = post.subtitle %}
   {% endif %}
@@ -24,7 +24,7 @@
     {% endif %}
   </div>
 
-  <a href="{{ site.baseurl }}{{ post_url }}">{{ short_title }}</a>
+  <a href="{{ site.baseurl }}{{ post_url }}" style="font-size: 20px;">{{ short_title }}</a>
 
   <div>
     {% if post.category %}

--- a/_includes/blog/post.html
+++ b/_includes/blog/post.html
@@ -1,46 +1,44 @@
-<li>
-  {% assign post_url = post.url | downcase | replace: ".html", "" %}
-  {% if post.subtitle %}
-    {% if page.pagination.title == "Blog" %}
-      {% assign short_title = post.title | append: " → " | append: post.subtitle %}
-    {% else %}
-      {% assign short_title = post.subtitle %}
-    {% endif %}
+{% assign post_url = post.url | downcase | replace: ".html", "" %}
+{% if post.subtitle %}
+  {% if page.pagination.title == "Blog" %}
+    {% assign short_title = post.title | append: " → " | append: post.subtitle %}
   {% else %}
-    {% assign short_title = post.title %}
+    {% assign short_title = post.subtitle %}
   {% endif %}
+{% else %}
+  {% assign short_title = post.title %}
+{% endif %}
 
-  <div class="container" style="padding-left: 0; padding-right: 0; padding-bottom: 2rem;">
-    <div>
-      {% if post.draft %}
+<div class="container" style="padding-left: 0; padding-right: 0; padding-bottom: 2rem;">
+  <div>
+    {% if post.draft %}
+      <span class="post-meta">Unpublished</span>
+    {% else %}
+      {% assign now = "now" | date: "%s" %}
+      {% assign date = post.date | date: "%s" %}
+      {% if date <= now %}
+        <span class="date-meta">{{ post.date }}</span>
+      {% else %}
         <span class="post-meta">Unpublished</span>
-      {% else %}
-        {% assign now = "now" | date: "%s" %}
-        {% assign date = post.date | date: "%s" %}
-        {% if date <= now %}
-          <span class="date-meta">{{ post.date }}</span>
-        {% else %}
-          <span class="post-meta">Unpublished</span>
-        {% endif %}
       {% endif %}
-    </div>
-
-    <a href="{{ site.baseurl }}{{ post_url }}">{{ short_title }}</a>
-
-    <div>
-      {% if post.category %}
-        {% unless page.pagination.category %}
-          {% assign category_to_show = post.category %}
-          {% assign tags_to_show = nil %}
-        {% endunless %}
-      {% else %}
-        {% unless page.pagination.tag %}
-          {% assign category_to_show = nil %}
-          {% assign tags_to_show = post.tags | sort %}
-        {% endunless %}
-      {% endif %}
-
-      {% include post/categorization.html %}
-    </div>
+    {% endif %}
   </div>
-</li>
+
+  <a href="{{ site.baseurl }}{{ post_url }}">{{ short_title }}</a>
+
+  <div>
+    {% if post.category %}
+      {% unless page.pagination.category %}
+        {% assign category_to_show = post.category %}
+        {% assign tags_to_show = nil %}
+      {% endunless %}
+    {% else %}
+      {% unless page.pagination.tag %}
+        {% assign category_to_show = nil %}
+        {% assign tags_to_show = post.tags | sort %}
+      {% endunless %}
+    {% endif %}
+
+    {% include post/categorization.html %}
+  </div>
+</div>

--- a/_includes/blog/posts-list.html
+++ b/_includes/blog/posts-list.html
@@ -1,8 +1,6 @@
-<ul class="list" style="list-style: none">
-  {% for post in paginator.posts %}
-    {% include blog/post.html %}
-  {% endfor %}
-</ul>
+{% for post in paginator.posts %}
+  {% include blog/post.html %}
+{% endfor %}
 
 {% if paginator.total_pages >= 8 %}
   {% include blog/pagination-trail.html %}

--- a/_includes/legos/list.html
+++ b/_includes/legos/list.html
@@ -1,11 +1,9 @@
 {% assign lego_list = site.legos | order: "date" | reverse %}
-<ul class="list" style="list-style: none">
-  {% for lego in lego_list %}
+{% for lego in lego_list %}
 
 <details>
-  <summary style="font-size: 32px; margin-bottom: 10px;">{{ lego.title }}</summary>
+  <summary style="font-size: 24px; margin-bottom: 10px;">{{ lego.title }}</summary>
   {{ lego.content }}
 </details>
 
-  {% endfor %}
-</ul>
+{% endfor %}

--- a/assets/css/_code.scss
+++ b/assets/css/_code.scss
@@ -1,6 +1,6 @@
 code {
   padding: .125rem .25rem;
-  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: "Roboto Mono", monospace;
   font-size: 15px;
   background-color: #f3f6fa;
   border: solid .0625rem #dce6f0;
@@ -12,7 +12,7 @@ pre {
   padding: .8rem;
   margin-top: 0;
   margin-bottom: 1rem;
-  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: "Roboto Mono", monospace;
   font-size: 15px;
   background-color: #f3f6fa;
   border: solid .0625rem #dce6f0;
@@ -35,7 +35,7 @@ pre {
 // This will make it so that the font size changes with the rest of the HTML container/div around it
 header-code {
   padding: .125rem .25rem;
-  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: "Roboto Mono", monospace;
   background-color: #f3f6fa;
   border: solid .0625rem #dce6f0;
   border-radius: .3rem;

--- a/assets/css/_code.scss
+++ b/assets/css/_code.scss
@@ -1,7 +1,7 @@
 code {
   padding: .125rem .25rem;
   font-family: "Roboto Mono", monospace;
-  font-size: 15px;
+  font-size: 14px;
   background-color: #f3f6fa;
   border: solid .0625rem #dce6f0;
   border-radius: .3rem;
@@ -13,7 +13,7 @@ pre {
   margin-top: 0;
   margin-bottom: 1rem;
   font-family: "Roboto Mono", monospace;
-  font-size: 15px;
+  font-size: 14px;
   background-color: #f3f6fa;
   border: solid .0625rem #dce6f0;
   border-radius: .3rem;
@@ -24,7 +24,7 @@ pre {
   > code {
     padding: 0;
     margin: 0;
-    font-size: 15px;
+    font-size: 14px;
     word-break: normal;
     word-wrap: normal;
     background: transparent;

--- a/assets/css/_google_fonts.scss
+++ b/assets/css/_google_fonts.scss
@@ -1,114 +1,149 @@
-// From https://fonts.googleapis.com/css?family=Open+Sans:400,700
+// From https://fonts.googleapis.com/css?family=Roboto+Mono:400,700
 
 /* cyrillic-ext */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFWJ0bf8pkAp6a.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhGq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFUZ0bf8pkAp6a.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhPq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-}
-/* greek-ext */
-@font-face {
-  font-family: 'Open Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFWZ0bf8pkAp6a.woff2) format('woff2');
-  unicode-range: U+1F00-1FFF;
 }
 /* greek */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVp0bf8pkAp6a.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhIq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFWp0bf8pkAp6a.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhEq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFW50bf8pkAp6a.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhFq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhLq3-cXbKD.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOX-hpKKSTj5PW.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhGq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOVuhpKKSTj5PW.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhPq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
-}
-/* greek-ext */
-@font-face {
-  font-family: 'Open Sans';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOXuhpKKSTj5PW.woff2) format('woff2');
-  unicode-range: U+1F00-1FFF;
 }
 /* greek */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOUehpKKSTj5PW.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhIq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOXehpKKSTj5PW.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhEq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOXOhpKKSTj5PW.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhFq3-cXbKDO1w.woff2) format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
-  font-family: 'Open Sans';
+  font-family: 'Roboto Mono';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOUuhpKKSTjw.woff2) format('woff2');
+  src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhLq3-cXbKD.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+// From https://fonts.googleapis.com/css?family=Nunito+Sans:400,700
+
+/* vietnamese */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cceyI9tAcVwob5A.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8ccezI9tAcVwob5A.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cce9I9tAcVwo.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBs5iU1ECVZl_86Y.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBs5jU1ECVZl_86Y.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBs5tU1ECVZl_.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/assets/css/_google_fonts.scss
+++ b/assets/css/_google_fonts.scss
@@ -1,3 +1,118 @@
+// From https://fonts.googleapis.com/css?family=Open+Sans:400,700
+
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFWJ0bf8pkAp6a.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFUZ0bf8pkAp6a.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFWZ0bf8pkAp6a.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVp0bf8pkAp6a.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFWp0bf8pkAp6a.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFW50bf8pkAp6a.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v17/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOX-hpKKSTj5PW.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOVuhpKKSTj5PW.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOXuhpKKSTj5PW.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOUehpKKSTj5PW.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOXehpKKSTj5PW.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOXOhpKKSTj5PW.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v17/mem5YaGs126MiZpBA-UN7rgOUuhpKKSTjw.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
 // From https://fonts.googleapis.com/css?family=Roboto+Mono:400,700
 
 /* cyrillic-ext */
@@ -94,56 +209,5 @@
   font-style: normal;
   font-weight: 700;
   src: url(https://fonts.gstatic.com/s/robotomono/v11/L0x5DF4xlVMF-BfR8bXMIjhLq3-cXbKD.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-// From https://fonts.googleapis.com/css?family=Nunito+Sans:400,700
-
-/* vietnamese */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cceyI9tAcVwob5A.woff2) format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-}
-/* latin-ext */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8ccezI9tAcVwob5A.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-/* latin */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe0qMImSLYBIv1o4X1M8cce9I9tAcVwo.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-/* vietnamese */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBs5iU1ECVZl_86Y.woff2) format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
-}
-/* latin-ext */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBs5jU1ECVZl_86Y.woff2) format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-/* latin */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v5/pe03MImSLYBIv1o4X1M8cc8GBs5tU1ECVZl_.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/assets/css/_site.scss
+++ b/assets/css/_site.scss
@@ -80,12 +80,12 @@ tr {
 }
 
 .post-meta {
-  font-size: 15px;
+  font-size: 16px;
   color: grey;
 }
 
 .date-meta {
-  font-size: 15px;
+  font-size: 16px;
   color: grey;
 }
 

--- a/assets/css/_site.scss
+++ b/assets/css/_site.scss
@@ -6,7 +6,7 @@ html, body {
 }
 
 body {
-  font-family: "Nunito Sans", "system-ui";
+  font-family: "Open Sans", "system-ui";
   font-size: 18px;
   line-height: 1.5;
   color: #606c71;

--- a/assets/css/_site.scss
+++ b/assets/css/_site.scss
@@ -6,7 +6,7 @@ html, body {
 }
 
 body {
-  font-family: "Open Sans";
+  font-family: "Nunito Sans", "system-ui";
   font-size: 18px;
   line-height: 1.5;
   color: #606c71;


### PR DESCRIPTION
## Changes
* Remove the `<ul></ul>` tags from the blog post list so that the left margin is aligned with the rest of the pages on the site instead of moved slightly to the right
* Use — instead of → when listing out blog posts with collection tags
* Update font sizes of blog page and post pages
* Remove the `<ul></ul>` tags from the lego list page so the left margin is aligned with the rest of the pages on the site instead of moved slightly to the right
* Make the summary tags of each lego block smaller font because it doesn't need to be so massive
* Update the monospace font to be `Roboto Mono` instead of randomly selecting a font
* Update the font sizes of monospace fonts because those fonts are naturally big
* Update version of jekyll-feed to take the new appendage of blog posts into account