### PR TITLE
Use cache@v2 in GitHub Actions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,7 +20,7 @@ jobs:
       run: sudo gem update --system 3.0.8 && sudo gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
 
     - name: Configure Gem Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -20,7 +20,7 @@ jobs:
       run: sudo gem update --system 3.0.8 && sudo gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
 
     - name: Configure Gem Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       run: sudo gem update --system 3.0.8 && sudo gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
 
     - name: Configure Gem Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}
@@ -33,7 +33,7 @@ jobs:
       run: JEKYLL_ENV=production bundle exec jekyll build --destination ./_site/
 
     - name: HTML Proofer
-      run: bash scripts/html_proofer.sh ${{ env.DEPLOYMENT_STATUS }}
+      run: bash scripts/html_proofer.sh
 
     - name: Rubocop
       run: bundle exec rubocop


### PR DESCRIPTION
## Changes

Use `cache@v2` in GitHub Actions because it was just released. Maybe now we can use caching on cron builds! Maybe not, but ya never know. It's good to stay as updated as possible anyway.