### PR TITLE
base_url vs baseurl

### DIFF
--- a/_includes/blog/post.html
+++ b/_includes/blog/post.html
@@ -24,7 +24,7 @@
     {% endif %}
   </div>
 
-  <a href="{{ site.baseurl }}{{ post_url }}" style="font-size: 20px;">{{ short_title }}</a>
+  <a href="{{ site.base_url }}{{ post_url }}" style="font-size: 20px;">{{ short_title }}</a>
 
   <div>
     {% if post.category %}

--- a/_includes/site/header.html
+++ b/_includes/site/header.html
@@ -28,7 +28,7 @@
             {% endif %}
 
             <li class="nav-item {{ active }}">
-              <a class="nav-link" href="{{ site.baseurl }}{{ navigation_url }}">{{ node.title }}
+              <a class="nav-link" href="{{ site.base_url }}{{ navigation_url }}">{{ node.title }}
                 {% if active == "active" %}
                   <span class="sr-only">(current)</span>
                 {% endif %}


### PR DESCRIPTION
Technically, both `site.base_url` and `site.baseurl` return the same thing. These are built-in Jekyll variables, so I don't set them myself. But, I want to be consistent between which ones I use, and I've decided to opt for the one with the underscore because all of my other variables have underscores.