### PR TITLE
Having vertical scroll shouldn't require horizontal scroll

### DIFF
--- a/assets/css/_site.scss
+++ b/assets/css/_site.scss
@@ -1,7 +1,7 @@
 html, body {
   min-width: 20rem;
   min-height: 100vh;
-  width: 100vw;
+  width: 100%;
   position: relative;
 }
 


### PR DESCRIPTION
## Changes

I noticed that on pages where there's a vertical scroll, it also creates a horizontal scroll. This shouldn't be required. So [this link](https://stackoverflow.com/questions/13569610/vertical-scrollbar-leads-to-horizontal-scrollbar) suggested changing `100vw` to `100%`.

![image](https://user-images.githubusercontent.com/7562793/86521848-7ab07300-be1b-11ea-8aba-9cfb8a03411c.png)
