### PR TITLE
Use more modals

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -279,9 +279,9 @@ When it's time to publish the post, you can either:
 
     ```
     # example (May 18, 2020 at 17:58 UTC):
-    @prscheduler 18-05-2020T17:58
+    @prscheduler 2020-05-18 17:58
 
-    @prscheduler DD-MM-YYYYTHH:MM
+    @prscheduler YYYY-MM-DD HH:MM
     ```
 
   * Wait for the `pr-scheduler` to respond saying the merge was scheduled

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -346,7 +346,7 @@ Alternatively, to use Lightbox to make the photo clickable, and then it'll zoom 
 ```html
 {% include elements/photo.html
     url="/assets/images/picture-01.jpg"
-    photo_width="2048" thumb_width="200" title="Picture 1" lightbox="gallery name goes here"
+    thumb_width="200" title="Picture 1" lightbox="gallery name goes here"
 %}
 ```
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@
 > If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
 > ```
 > # example (May 18, 2020 at 17:58 UTC):
-> @prscheduler 18-05-2020T17:58
+> @prscheduler 2020-05-18 17:58
 >
-> @prscheduler DD-MM-YYYYTHH:MM
+> @prscheduler YYYY-MM-DD HH:MM
 > ```

--- a/_blog_posts/adding-pagination-without-jekyll.md
+++ b/_blog_posts/adding-pagination-without-jekyll.md
@@ -17,7 +17,10 @@ Turns out, the Google doesn't have a lot of other suggestions on pagination. But
 Of course, I started with the things I know how to do best: copy-paste 💁🏻‍♀️. I started with [this blob](https://github.com/UMM-CSci/senior-seminar/blob/master/seminars.html#L63-L80), of course edited to suit my HTML file. Surprisingly, bits of this work right out of the box. But... the pagination isn't pretty, which is very important to me.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741690227/in/album-72157710863695862/" title="bad_pagination_bar"><img class="image" src="https://live.staticflickr.com/65535/48741690227_e27cb82884.jpg" width="450" height="367" alt="Bad pagination bar"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741690227_e27cb82884.jpg"
+      photo_width="450" thumb_width="400" title="Ugly vertical pagination bar" lightbox="Pagination"
+  %}
 </div>
 
 So, I went on a mission to figure out how to make a prettier pagination bar. After a couple of hours, and a good night's sleep, I realized that the answer lies in the `css/main.scss` file. Specifically, this line:
@@ -37,7 +40,10 @@ was not found.
 Clearly, that means my CSS is broken. But I didn't quite understand why 😕. The repository that I was copying pagination from included this line:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741503991/in/album-72157710863695862/" title="primer_submodule_directory"><img class="image" src="https://live.staticflickr.com/65535/48741503991_c9f4ec3ce4_o.png" width="486" height="45" alt="primer_submodule_directory"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741503991_ac5c550274.jpg"
+      photo_width="486" thumb_width="450" title="Primer as a submodule" lightbox="Pagination"
+  %}
 </div>
 
 Since I couldn't understand out why my CSS was broken, I figured it was time for me to try to add that "directory" to my repo.
@@ -63,7 +69,10 @@ After I finished succesfully adding the `primer` submodule 😌, all I had to do
 back to my `main.scss`, and finally the pagination was beautiful:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741504061/in/album-72157710863695862/" title="lovely_pagination_bar"><img class="image" src="https://live.staticflickr.com/65535/48741504061_7ebbd630fa.jpg" width="450" height="311" alt="Lovely pagination bar"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741504061_7ebbd630fa.jpg"
+      photo_width="450" thumb_width="400" title="Pagination bar that's much better" lightbox="Pagination"
+  %}
 </div>
 
 I was thrilled with the outcome of this pagination (even though it wasn't Jekyll's officially supported pagination), and I committed to `gh-pages`. However, perhaps a day later, I noticed something wrong with my CSS formatting. Perhaps you can notice it if you compare the before-pretty-pagination and the after-pretty-pagination pictures... I'll give you a hint: it has to do with the indentation and spacing of the words. Somehow, making the pagination bar pretty messed up my CSS formatting!

--- a/_blog_posts/adding-pagination-without-jekyll.md
+++ b/_blog_posts/adding-pagination-without-jekyll.md
@@ -19,7 +19,7 @@ Of course, I started with the things I know how to do best: copy-paste 💁🏻�
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741690227_e27cb82884.jpg"
-      photo_width="450" thumb_width="400" title="Ugly vertical pagination bar" lightbox="Pagination"
+      thumb_width="400" title="Ugly vertical pagination bar" lightbox="Pagination"
   %}
 </div>
 
@@ -42,7 +42,7 @@ Clearly, that means my CSS is broken. But I didn't quite understand why 😕. Th
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741503991_ac5c550274.jpg"
-      photo_width="486" thumb_width="450" title="Primer as a submodule" lightbox="Pagination"
+      thumb_width="450" title="Primer as a submodule" lightbox="Pagination"
   %}
 </div>
 
@@ -71,7 +71,7 @@ back to my `main.scss`, and finally the pagination was beautiful:
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741504061_7ebbd630fa.jpg"
-      photo_width="450" thumb_width="400" title="Pagination bar that's much better" lightbox="Pagination"
+      thumb_width="400" title="Pagination bar that's much better" lightbox="Pagination"
   %}
 </div>
 

--- a/_blog_posts/opening-links-in-new-tabs-via-javascript.md
+++ b/_blog_posts/opening-links-in-new-tabs-via-javascript.md
@@ -63,7 +63,10 @@ So, I endeavored to find the best way to set my Markdown links to open in new ta
 And with either of the solutions, GitHub does this weird raw text italisizing that makes looking at these files very painful. Here's an example. Do you see how half of the paragraphs have been entirely italisized?
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/49386386903/in/album-72157710863695862/" title="GitHub&#x27;s weird italisizing"><img class="image" src="https://live.staticflickr.com/65535/49386386903_198f4cc1e2_z.jpg" width="986" height="962" alt="GitHub&#x27;s weird italisizing"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/49386386903_198f4cc1e2_b.jpg"
+      photo_width="986" thumb_width="400" title="GitHub's weird italisizing" lightbox="Opening tabs"
+  %}
 </div>
 
 So, neither of these options are perfect, and I don't like either of them. I want to be able to easily type a link, with the traditional Markdown format (`[link](url)`), and I want the link to open in a new tab on the browser (converted to HTML from kramdown), and to read in GitHub properly (not include the `{:target="_blank"}`).

--- a/_blog_posts/opening-links-in-new-tabs-via-javascript.md
+++ b/_blog_posts/opening-links-in-new-tabs-via-javascript.md
@@ -65,7 +65,7 @@ And with either of the solutions, GitHub does this weird raw text italisizing th
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49386386903_198f4cc1e2_b.jpg"
-      photo_width="986" thumb_width="400" title="GitHub's weird italisizing" lightbox="Opening tabs"
+      thumb_width="400" title="GitHub's weird italisizing" lightbox="Opening tabs"
   %}
 </div>
 

--- a/_blog_posts/time-zones-utc-and-javascript-oh-my.md
+++ b/_blog_posts/time-zones-utc-and-javascript-oh-my.md
@@ -136,7 +136,7 @@ In our example, I published a post on the 17th of January at night in CST. But w
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49498384557_688bf3652a_o.png"
-      photo_width="530" thumb_width="450" title="Time zone shown in URL" lightbox="Time zones"
+      thumb_width="450" title="Time zone shown in URL" lightbox="Time zones"
   %}
 </div>
 

--- a/_blog_posts/time-zones-utc-and-javascript-oh-my.md
+++ b/_blog_posts/time-zones-utc-and-javascript-oh-my.md
@@ -134,7 +134,10 @@ I'm hiding a lot of the effort this took me... don't get me wrong, it took me wh
 In our example, I published a post on the 17th of January at night in CST. But we see now, that if I travel to France and look back at past blog posts, it'll look as if it was published on the 18th of January. BUT, the URL of the blog post will include the published date. See an example below:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/49498384557/in/album-72157710863695862/" title="Link to blog post including the date"><img class="image" src="https://live.staticflickr.com/65535/49498384557_42bd218c3d.jpg" width="500" height="31" alt="Link to blog post including the date"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/49498384557_688bf3652a_o.png"
+      photo_width="530" thumb_width="450" title="Time zone shown in URL" lightbox="Time zones"
+  %}
 </div>
 
 If the date the site is showing the reader is moving around depending on the readers' location, then this is confusing—the URL date won't change!

--- a/_blog_posts/using-jekyll-paginate-v2.md
+++ b/_blog_posts/using-jekyll-paginate-v2.md
@@ -15,7 +15,7 @@ But, soon after I started getting an upgrade in my CSS game, I realized that my 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741504061_7ebbd630fa.jpg"
-      photo_width="450" thumb_width="400" title="Pagination bar that's now not quite as lovely" lightbox="Pagination"
+      thumb_width="400" title="Pagination bar that's now not quite as lovely" lightbox="Pagination"
   %}
 </div>
 
@@ -54,7 +54,7 @@ After all of that work, I now have a pagination bar that makes me proud of this 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49241327792_e87715127e_o.png"
-      photo_width="994" thumb_width="400" title="Pagination bar that can grow with my site" lightbox="Pagination"
+      thumb_width="400" title="Pagination bar that can grow with my site" lightbox="Pagination"
   %}
 </div>
 

--- a/_blog_posts/using-jekyll-paginate-v2.md
+++ b/_blog_posts/using-jekyll-paginate-v2.md
@@ -13,7 +13,10 @@ A couple of weeks ago, I started the endeavor of adding Bootstrap to this websit
 But, soon after I started getting an upgrade in my CSS game, I realized that my pagination bar on my blog site was sorely outdated 😢. At one point, I had the nerve to call this pagination bar beautiful:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741504061/in/album-72157710863695862/" title="lovely_pagination_bar"><img class="image" src="https://live.staticflickr.com/65535/48741504061_7ebbd630fa.jpg" width="450" height="311" alt="Lovely pagination bar"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741504061_7ebbd630fa.jpg"
+      photo_width="450" thumb_width="400" title="Pagination bar that's now not quite as lovely" lightbox="Pagination"
+  %}
 </div>
 
 But since completely revamping the whole looks of the site, this pagination bar was no longer acceptable. It was old fashioned, wouldn't remember the page you were on if you navigated forward and back in your browser, and didn't have pretty buttons. It was time for me to look into alternate pagination options.
@@ -49,7 +52,10 @@ Despite all of this work, now every single tag and category filters blog posts p
 After all of that work, I now have a pagination bar that makes me proud of this website. Just add in a few more pretty icons, and I'm satisfied 😁.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/49241327792/in/album-72157710863695862/" title="Bootstrap Pagination"><img class="image" src="https://live.staticflickr.com/65535/49241327792_44bf877bcb.jpg" width="500" height="304" alt="Bootstrap Pagination"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/49241327792_e87715127e_o.png"
+      photo_width="994" thumb_width="400" title="Pagination bar that can grow with my site" lightbox="Pagination"
+  %}
 </div>
 
 ---

--- a/_blog_posts/welcome-to-kenya/jambo.md
+++ b/_blog_posts/welcome-to-kenya/jambo.md
@@ -20,7 +20,10 @@ But I'm getting ahead of myself. Let's start with the plane ride. We rode with K
 Despite the heat, we persevered, and 9 hours later, and a few naps, movies, and meals later, we were passing over the Sahara Desert. Then another few hours later, our plane was finally nearing Nairobi. If there's anything to remind us that Africa is **huge**, it's the amount of time it took us to cross the continent.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606523/in/album-72157710860887528/" title="fly_over_nairobi"><img class="image" src="https://live.staticflickr.com/65535/48740606523_77e7b836e4_o.jpg" width="500" height="375" alt="Our plane flying towards Nairobi"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606523_77e7b836e4_o.jpg"
+      photo_width="994" thumb_width="400" title="Map as we flew over Nairobi" lightbox="Jambo"
+  %}
 </div>
 
 After landing, getting through Customs, and picking up our bags, the first thing I noticed was the amount of guns the guards at the airport had. I'm not really a big gun person, so I'm not sure what types of guns they were, but I think maybe they were AK-47s or something... they looked to be military style 🙀. And they were all over. A few of us theorized that they were actually empty, and that people were only carrying them around for show... I didn't feel like seeing if they were right or not. Either way, by the end of the trip, I eventually got used to the security guards always carrying weapons (huge rifles, large sticks, sharp knives, etc).

--- a/_blog_posts/welcome-to-kenya/jambo.md
+++ b/_blog_posts/welcome-to-kenya/jambo.md
@@ -22,7 +22,7 @@ Despite the heat, we persevered, and 9 hours later, and a few naps, movies, and 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606523_77e7b836e4_o.jpg"
-      photo_width="994" thumb_width="400" title="Map as we flew over Nairobi" lightbox="Jambo"
+      thumb_width="400" title="Map as we flew over Nairobi" lightbox="Jambo"
   %}
 </div>
 

--- a/_blog_posts/welcome-to-kenya/kwaheri.md
+++ b/_blog_posts/welcome-to-kenya/kwaheri.md
@@ -20,7 +20,7 @@ When we got to the airport, our trip leaders were right; it was busy. We didn't 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48871541883_f68f5627c5_o.jpg"
-      photo_width="960" thumb_width="400" title="Our last night in Kenya" lightbox="Kwaheri"
+      thumb_width="400" title="Our last night in Kenya" lightbox="Kwaheri"
   %}
 </div>
 

--- a/_blog_posts/welcome-to-kenya/kwaheri.md
+++ b/_blog_posts/welcome-to-kenya/kwaheri.md
@@ -18,7 +18,10 @@ We hurriedly gave the last of our Kenya Shilling cash to our drivers as tips �
 When we got to the airport, our trip leaders were right; it was busy. We didn't have time to hug our drivers one last time, so instead, we pushed our way to the long lines that awaited us inside the airport doors. Kwaheri, Kenya 👋🏼.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48871541883/in/album-72157710860887528/" title="Van 1 on our last day"><img class="image" src="https://live.staticflickr.com/65535/48871541883_c67c5270c0.jpg" width="500" height="375" alt="Van 1 on our last day"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48871541883_f68f5627c5_o.jpg"
+      photo_width="960" thumb_width="400" title="Our last night in Kenya" lightbox="Kwaheri"
+  %}
 </div>
 
 The above picture is of our van on our last day. In it we have Abdi (our driver), Impreet, Myra, Kristen, Andrew, and Jesse as our "photographer." Even over a month later, there's still a part of me that misses them 😢.

--- a/_blog_posts/welcome-to-kenya/the-cuisine-and-the-lodging.md
+++ b/_blog_posts/welcome-to-kenya/the-cuisine-and-the-lodging.md
@@ -52,7 +52,14 @@ During the day, the watering hole and surrounding area has hyenas, buffalo, and 
 The rooms are small, but that's by design. They feel cozy and snug. The hallways are a maze, but you only need to know how to get to a few places: your room, the entrance/exit, the decks, and the restaurant (but you can get to the food from the decks).
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48797244476/in/album-72157710860887528/" title="the_ark"><img class="image" src="https://live.staticflickr.com/65535/48797244476_b8b7e63c5d_o.jpg" width="500" height="375" alt="Our rooms at the Ark"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48797244476_b8b7e63c5d_o.jpg"
+      photo_width="960" thumb_width="400" title="The Ark lodging" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826445088_4fcce75760_o.jpg"
+      photo_width="4032" thumb_width="400" title="The Ark's buffet line" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 The air was a bit chilly at night (because of the higher altitude in the mountains), but the staff brought warm hot water packs to each bed at night, so our tootsies stayed nice and cozy.
@@ -74,9 +81,14 @@ They provided an array of extra activities we could do. Our tour guide set up a 
 I don't have many pictures of the exterior of Sarova Shaba Game Lodge, and that's really a pity; the best thing about this resort was the beautiful resort grounds. But, the good news is that their website has plenty of pictures featuring the resort grounds. Here's one picture of our room and one of the buffet line:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48872057586/in/album-72157710860887528/" title="Sarova_Shaba_pool"><img class="image" src="https://live.staticflickr.com/65535/48872057586_8a1e440b3d.jpg" width="500" height="375" alt="Sarova_Shaba_pool"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826445063/in/album-72157710860887528/" title="Sarova_Shaba"><img class="image" src="https://live.staticflickr.com/65535/48826445063_a4575a3694.jpg" width="500" height="375" alt="Sarova Shaba room"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826445088/in/album-72157710860887528/" title="The ark&#x27;s buffet line"><img class="image" src="https://live.staticflickr.com/65535/48826445088_3132fa06a3.jpg" width="375" height="500" alt="The ark&#x27;s buffet line"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48872057586_638b72d2ca_o.jpg"
+      photo_width="960" thumb_width="400" title="Sarova Shaba pool" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826445063_35a542e32e_o.jpg"
+      photo_width="960" thumb_width="400" title="Sarova Shaba Room" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 ### The Samburu Village Visit
@@ -90,11 +102,26 @@ Children do attend school... now. In school, young children will learn Swahili a
 Women and mothers take care of the children, take care of the livestock, do beading and art projects, and sell their crafts to visitors and other tribes. We even got the chance to purchase some of their handmade jewelry and crafts.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48799101398/in/album-72157710860887528/" title="samburu_village"><img class="image" src="https://live.staticflickr.com/65535/48799101398_fff90651b6.jpg" width="500" height="375" alt="samburu_village"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48799451886/in/album-72157710860887528/" title="samburu_village_children"><img class="image" src="https://live.staticflickr.com/65535/48799451886_edfe7f12da.jpg" width="500" height="333" alt="samburu_village_children"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826820661/in/album-72157710860887528/" title="Samburu_village"><img class="image" src="https://live.staticflickr.com/65535/48826820661_aed40f6716.jpg" width="500" height="281" alt="Samburu_village"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826444963/in/album-72157710860887528/" title="Samburu_hut"><img class="image" src="https://live.staticflickr.com/65535/48826444963_e60dced23d.jpg" width="500" height="375" alt="The hut in the Samburu village"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826445033/in/album-72157710860887528/" title="Samburu_elders"><img class="image" src="https://live.staticflickr.com/65535/48826445033_dbaa06b427.jpg" width="500" height="375" alt="Samburu_elders"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48799101398_ac4b7ba7c5_o.jpg"
+      photo_width="4032" thumb_width="400" title="Samburu village" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48799451886_c952b2af60_o.jpg"
+      photo_width="6000" thumb_width="400" title="Samburu children" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826820661_e3168ba066_o.png"
+      photo_width="2208" thumb_width="400" title="Samburu village" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826444963_7102bf89d2_o.jpg"
+      photo_width="4032" thumb_width="400" title="Samburu hut" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826445033_8dc2101822_o.jpg"
+      photo_width="4032" thumb_width="400" title="Samburu elders" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 ## Ol Pejeta ☞ [Sweetwaters Serena Camp](https://www.serenahotels.com/serenasweetwaters/en/default.html)
@@ -102,8 +129,14 @@ Women and mothers take care of the children, take care of the livestock, do bead
 Ol Pejeta's Sweetwaters Serena Camp was my favorite place we stayed. It's a tented camp, which means each suite is a full tent. However, it's not the types of tents that you'd think of when it comes to camping. These tents are on solid tile/wood/brick bases, have solid roofs, and have full bathrooms inside of them, including a toilet, shower, and sink. The tents were clean and well-kept. Take a look at the inside of one of the tents!
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48796885958/in/album-72157710860887528/" title="sweetwaters"><img class="image" src="https://live.staticflickr.com/65535/48796885958_594a93b9e1.jpg" width="375" height="500" alt="sweetwaters"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48872252992/in/album-72157710860887528/" title="Sweetwaters_tent"><img class="image" src="https://live.staticflickr.com/65535/48872252992_3ddc673f1b.jpg" width="500" height="333" alt="Sweetwaters_tent"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48796885958_e5f240a3e4_o.jpg"
+      photo_width="720" thumb_width="200" title="Sweetwaters lodging" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48872252992_5a8b9aea8d_o.jpg"
+      photo_width="960" thumb_width="400" title="Sweetwaters tent" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 The walk from the main resort buildings to the tents was also quite relaxing and beautiful. We even saw a strange bird land on the resort, as well as a couple of small gazelles.
@@ -113,7 +146,10 @@ All of the resorts had very similar type of food, but one super cool thing that 
 Sweetwaters Serena Camp is on the Equator. No joke, the sign at the entrance gave the latitude and longitude—latitude was 00.00:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48802026607/in/album-72157710860887528/" title="Sweetwaters Serena Camp"><img class="image" src="https://live.staticflickr.com/65535/48802026607_8bb9580f56.jpg" width="500" height="375" alt="Sweetwaters Serena Camp"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48802026607_bf7dedd9ea_o.jpg"
+      photo_width="4032" thumb_width="400" title="We stayed on the equator!" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 So, walking around in direct sunlight was a bit hot. However, as the night came, the air cooled off to a chilly 55°F. However, it wasn't too cold for my Minnesota tendencies, and I was just fine without a jacket.
@@ -137,9 +173,18 @@ Essentially, any time between when the sun sets and 7am the next morning, the re
 However, if you're lucky, your cabin windows (or deck on a top floor), gives you a beautiful chance to see some hippos out of the water. My partner and I stayed up trying to look for the hippos, and we even got up periodically in the middle of the night just to look out the windows to see if we could see anything. But we weren't so lucky. It was nice that our suite provided us a little couch to sit on while we gazed out the windows though:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48796885438/in/album-72157710860887528/" title="sopa_lake_naivasha"><img class="image" src="https://live.staticflickr.com/65535/48796885438_df62bf99d7.jpg" width="375" height="500" alt="sopa_lake_naivasha"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48797382142/in/album-72157710860887528/" title="sopa_lake_naivasha_2"><img class="image" src="https://live.staticflickr.com/65535/48797382142_d96980a318.jpg" width="500" height="375" alt="sopa_lake_naivasha_2"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826444793/in/album-72157710860887528/" title="Lake_Naivasha"><img class="image" src="https://live.staticflickr.com/65535/48826444793_45dfe8f14d.jpg" width="500" height="375" alt="Lake_Naivasha"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48796885438_3c889d5496_o.jpg"
+      photo_width="720" thumb_width="200" title="Sopa lodging" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48797382142_5ed4a79360_o.jpg"
+      photo_width="960" thumb_width="300" title="Sopa room with couch to watch the hippos" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826444793_daf66a4e6d_o.jpg"
+      photo_width="960" thumb_width="300" title="Sopa lodging building" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 Feel free to check out even more pictures from Sopa Resort's gallery on their website!
@@ -157,7 +202,10 @@ Like some of the other resorts, Fig Tree Camp also offered a special excursion: 
 Oh, the last thing I'll mention about Fig Tree Camp: they had limited times the power and hot water was on. The power was on in the morning and afternoon/evening, and the hot water ran in the morning (from maybe 6am-9am), and in the evening (approximately 6pm-9pm). I know because the morning of the hot air balloon ride, I took an ice-cold shower.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48826443083/in/album-72157710860887528/" title="Maasai_Mara_room"><img class="image" src="https://live.staticflickr.com/65535/48826443083_b335a58a4f.jpg" width="375" height="500" alt="Maasai_Mara_room"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48826443083_3125e40674_o.jpg"
+      photo_width="4032" thumb_width="400" title="Maasai Mara room" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 ### The Maasai Village Visit
@@ -173,9 +221,18 @@ Also, the Samburu village was just a bunch of huts in a scattered area. But the 
 The last thing I'll mention is that both tribes do a type of ceremonial activity where the boys/warriors will jump vertically in the air. A woman decides which man is a good suitor based on how high he can jump—the higher the better. While watching an example ceremony take place, we also learned that the men in the Maasai tribe don't wear underwear underneath their clothes... don't ask us how.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48799594437/in/album-72157710860887528/" title="maasai_village_jumping_ceremony"><img class="image" src="https://live.staticflickr.com/65535/48799594437_a54226509b.jpg" width="281" height="500" alt="maasai_village_jumping_ceremony"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48799451771/in/album-72157710860887528/" title="maasai_village"><img class="image" src="https://live.staticflickr.com/65535/48799451771_0b6e938b59.jpg" width="356" height="500" alt="maasai_village"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48799595727/in/album-72157710860887528/" title="maasai_mara_village_in_ceremony"><img class="image" src="https://live.staticflickr.com/65535/48799595727_ee144de5d9.jpg" width="500" height="375" alt="maasai_mara_village_in_ceremony"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48799594437_12567ee4f7_o.jpg"
+      photo_width="2988" thumb_width="250" title="Maasai Mara jumping ceremony" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48799451771_dfeae19ebe_o.jpg"
+      photo_width="1400" thumb_width="250" title="Maasai Mara man and child" lightbox="Cuisine and Lodging"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48799595727_faf4d27004_o.jpg"
+      photo_width="4032" thumb_width="400" title="Maasai Mara village" lightbox="Cuisine and Lodging"
+  %}
 </div>
 
 ## Conclusion

--- a/_blog_posts/welcome-to-kenya/the-cuisine-and-the-lodging.md
+++ b/_blog_posts/welcome-to-kenya/the-cuisine-and-the-lodging.md
@@ -54,11 +54,11 @@ The rooms are small, but that's by design. They feel cozy and snug. The hallways
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48797244476_b8b7e63c5d_o.jpg"
-      photo_width="960" thumb_width="400" title="The Ark lodging" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="The Ark lodging" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826445088_4fcce75760_o.jpg"
-      photo_width="4032" thumb_width="400" title="The Ark's buffet line" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="The Ark's buffet line" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -83,11 +83,11 @@ I don't have many pictures of the exterior of Sarova Shaba Game Lodge, and that'
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48872057586_638b72d2ca_o.jpg"
-      photo_width="960" thumb_width="400" title="Sarova Shaba pool" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Sarova Shaba pool" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826445063_35a542e32e_o.jpg"
-      photo_width="960" thumb_width="400" title="Sarova Shaba Room" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Sarova Shaba Room" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -104,23 +104,23 @@ Women and mothers take care of the children, take care of the livestock, do bead
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799101398_ac4b7ba7c5_o.jpg"
-      photo_width="4032" thumb_width="400" title="Samburu village" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Samburu village" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799451886_c952b2af60_o.jpg"
-      photo_width="6000" thumb_width="400" title="Samburu children" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Samburu children" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826820661_e3168ba066_o.png"
-      photo_width="2208" thumb_width="400" title="Samburu village" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Samburu village" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826444963_7102bf89d2_o.jpg"
-      photo_width="4032" thumb_width="400" title="Samburu hut" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Samburu hut" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826445033_8dc2101822_o.jpg"
-      photo_width="4032" thumb_width="400" title="Samburu elders" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Samburu elders" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -131,11 +131,11 @@ Ol Pejeta's Sweetwaters Serena Camp was my favorite place we stayed. It's a tent
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48796885958_e5f240a3e4_o.jpg"
-      photo_width="720" thumb_width="200" title="Sweetwaters lodging" lightbox="Cuisine and Lodging"
+      thumb_width="200" title="Sweetwaters lodging" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48872252992_5a8b9aea8d_o.jpg"
-      photo_width="960" thumb_width="400" title="Sweetwaters tent" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Sweetwaters tent" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -148,7 +148,7 @@ Sweetwaters Serena Camp is on the Equator. No joke, the sign at the entrance gav
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48802026607_bf7dedd9ea_o.jpg"
-      photo_width="4032" thumb_width="400" title="We stayed on the equator!" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="We stayed on the equator!" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -175,15 +175,15 @@ However, if you're lucky, your cabin windows (or deck on a top floor), gives you
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48796885438_3c889d5496_o.jpg"
-      photo_width="720" thumb_width="200" title="Sopa lodging" lightbox="Cuisine and Lodging"
+      thumb_width="200" title="Sopa lodging" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48797382142_5ed4a79360_o.jpg"
-      photo_width="960" thumb_width="300" title="Sopa room with couch to watch the hippos" lightbox="Cuisine and Lodging"
+      thumb_width="300" title="Sopa room with couch to watch the hippos" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826444793_daf66a4e6d_o.jpg"
-      photo_width="960" thumb_width="300" title="Sopa lodging building" lightbox="Cuisine and Lodging"
+      thumb_width="300" title="Sopa lodging building" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -204,7 +204,7 @@ Oh, the last thing I'll mention about Fig Tree Camp: they had limited times the 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826443083_3125e40674_o.jpg"
-      photo_width="4032" thumb_width="400" title="Maasai Mara room" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Maasai Mara room" lightbox="Cuisine and Lodging"
   %}
 </div>
 
@@ -223,15 +223,15 @@ The last thing I'll mention is that both tribes do a type of ceremonial activity
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799594437_12567ee4f7_o.jpg"
-      photo_width="2988" thumb_width="250" title="Maasai Mara jumping ceremony" lightbox="Cuisine and Lodging"
+      thumb_width="250" title="Maasai Mara jumping ceremony" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799451771_dfeae19ebe_o.jpg"
-      photo_width="1400" thumb_width="250" title="Maasai Mara man and child" lightbox="Cuisine and Lodging"
+      thumb_width="250" title="Maasai Mara man and child" lightbox="Cuisine and Lodging"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799595727_faf4d27004_o.jpg"
-      photo_width="4032" thumb_width="400" title="Maasai Mara village" lightbox="Cuisine and Lodging"
+      thumb_width="400" title="Maasai Mara village" lightbox="Cuisine and Lodging"
   %}
 </div>
 

--- a/_blog_posts/welcome-to-kenya/the-game-drives.md
+++ b/_blog_posts/welcome-to-kenya/the-game-drives.md
@@ -42,15 +42,15 @@ The Ark is where we saw our first cape buffalo, hyenas, warthogs (think Pumbaa!)
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606838_c65187533b_o.jpg"
-      photo_width="600" thumb_width="200" title="Buffalo at the Ark" lightbox="Game Drives"
+      thumb_width="200" title="Buffalo at the Ark" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740934946_f3e99feb9b_o.jpg"
-      photo_width="600" thumb_width="200" title="Buffalos at the Ark" lightbox="Game Drives"
+      thumb_width="200" title="Buffalos at the Ark" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119477_98156ea6e6_o.jpg"
-      photo_width="600" thumb_width="200" title="Elephants at the Ark" lightbox="Game Drives"
+      thumb_width="200" title="Elephants at the Ark" lightbox="Game Drives"
   %}
 </div>
 
@@ -59,11 +59,11 @@ At the Aberdares Country Club, near the Ark, we also saw some baboons, impalas, 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606758_718889f723_o.jpg"
-      photo_width="450" thumb_width="150" title="Peacock at Aberdares Country Club" lightbox="Game Drives"
+      thumb_width="150" title="Peacock at Aberdares Country Club" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935281_69b63473b8_o.jpg"
-      photo_width="600" thumb_width="200" title="Peacock close-up at Aberdares Country Club" lightbox="Game Drives"
+      thumb_width="200" title="Peacock close-up at Aberdares Country Club" lightbox="Game Drives"
   %}
 </div>
 
@@ -76,35 +76,35 @@ Samburu is an area north of the equator, located in the center of Kenya. The lan
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606393_4f24904b75_o.jpg"
-      photo_width="600" thumb_width="200" title="Baboons at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Baboons at Samburu" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606453_02c1dcf73c_o.jpg"
-      photo_width="600" thumb_width="200" title="Elephant at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Elephant at Samburu" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119692_f8d37d4a98_o.jpg"
-      photo_width="600" thumb_width="200" title="Oryx at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Oryx at Samburu" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935066_7e21df8970_o.jpg"
-      photo_width="600" thumb_width="200" title="Reticulated giraffes at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Reticulated giraffes at Samburu" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606638_752252d3bd_o.jpg"
-      photo_width="600" thumb_width="200" title="Impala at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Impala at Samburu" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606678_6d9f3482a6_o.jpg"
-      photo_width="600" thumb_width="200" title="Lioness at Samburu (look closely)" lightbox="Game Drives"
+      thumb_width="200" title="Lioness at Samburu (look closely)" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119697_5b99e26766_o.jpg"
-      photo_width="726000" thumb_width="200" title="Ostrich at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Ostrich at Samburu" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119832_225ebe076d_o.jpg"
-      photo_width="600" thumb_width="200" title="Zebras at Samburu" lightbox="Game Drives"
+      thumb_width="200" title="Zebras at Samburu" lightbox="Game Drives"
   %}
 </div>
 
@@ -119,15 +119,15 @@ We managed to visit the Chimpanzee and Rhinoceros conservancies while we were th
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119427_950e08953a_o.jpg"
-      photo_width="600" thumb_width="200" title="Chimpanzee at Ol Pejeta" lightbox="Game Drives"
+      thumb_width="200" title="Chimpanzee at Ol Pejeta" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119722_6ea09cfa61_o.jpg"
-      photo_width="600" thumb_width="200" title="Rhino at Ol Pejeta... and we got to pet it!" lightbox="Game Drives"
+      thumb_width="200" title="Rhino at Ol Pejeta... and we got to pet it!" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606828_4cca69618e_o.jpg"
-      photo_width="450" thumb_width="150" title="Rhino feeding at Ol Pejeta" lightbox="Game Drives"
+      thumb_width="150" title="Rhino feeding at Ol Pejeta" lightbox="Game Drives"
   %}
 </div>
 
@@ -146,7 +146,7 @@ The resort where we stayed is famous for having hippos come graze on the grass r
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935336_73f8a59ae8_o.jpg"
-      photo_width="450" thumb_width="150" title="Waterbucks near Lake Naivasha" lightbox="Game Drives"
+      thumb_width="150" title="Waterbucks near Lake Naivasha" lightbox="Game Drives"
   %}
 </div>
 
@@ -161,63 +161,63 @@ Although I wish I could attach all of the pictures we have from the Maasai Mara,
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740934961_f96f3dd557_o.jpg"
-      photo_width="600" thumb_width="200" title="Cheetah at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Cheetah at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935001_ed2ef1a21f_o.jpg"
-      photo_width="600" thumb_width="200" title="Elephants at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Elephants at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119482_2a65f2332a_o.jpg"
-      photo_width="600" thumb_width="200" title="Momma elephant with baby at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Momma elephant with baby at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119542_20ff32c710_o.jpg"
-      photo_width="600" thumb_width="200" title="Giraffe at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Giraffe at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119572_75b99d2f3e_o.jpg"
-      photo_width="600" thumb_width="200" title="Giraffe headshot at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Giraffe headshot at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935081_640dc843a8_o.jpg"
-      photo_width="600" thumb_width="200" title="Hippo at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Hippo at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935106_67389659e4_o.jpg"
-      photo_width="600" thumb_width="200" title="Swimming hippo at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Swimming hippo at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119617_67389659e4_o.jpg"
-      photo_width="450" thumb_width="200" title="Hyenas at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Hyenas at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935151_cedbc943a3_o.jpg"
-      photo_width="600" thumb_width="200" title="Leopard laying around at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Leopard laying around at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606698_6ae7e8c66d_o.jpg"
-      photo_width="600" thumb_width="200" title="Lions at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Lions at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935211_3504edbc65_o.jpg"
-      photo_width="600" thumb_width="200" title="Yawning lion at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Yawning lion at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935321_f29e95c343_o.jpg"
-      photo_width="600" thumb_width="200" title="Warthogs at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Warthogs at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119787_f547fdb8b4_o.jpg"
-      photo_width="600" thumb_width="200" title="Wildebeests at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Wildebeests at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935386_f3d51837f8_o.jpg"
-      photo_width="550" thumb_width="200" title="Walking wildebeests at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Walking wildebeests at Maasai Mara" lightbox="Game Drives"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119842_aa42e45571_o.jpg"
-      photo_width="600" thumb_width="200" title="Zebras at Maasai Mara" lightbox="Game Drives"
+      thumb_width="200" title="Zebras at Maasai Mara" lightbox="Game Drives"
   %}
 </div>
 

--- a/_blog_posts/welcome-to-kenya/the-game-drives.md
+++ b/_blog_posts/welcome-to-kenya/the-game-drives.md
@@ -40,16 +40,31 @@ We started our safaris at the Ark in the Aberdares mountain range. I'll talk mor
 The Ark is where we saw our first cape buffalo, hyenas, warthogs (think Pumbaa!), and elephants.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606838/in/album-72157710860887528/" title="single_buffalo_at_ark"><img class="image" src="https://live.staticflickr.com/65535/48740606838_d469ce0358_z.jpg" width="500" height="375" alt="Buffalo at the Ark posing for pictures"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740934946/in/album-72157710860887528/" title="buffalo_at_ark"><img class="image" src="https://live.staticflickr.com/65535/48740934946_d32e31e68f_z.jpg" width="500" height="375" alt="Buffalo at the Ark"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119477/in/album-72157710860887528/" title="elephants_at_ark"><img class="image" src="https://live.staticflickr.com/65535/48741119477_5edfd2cf84_z.jpg" width="500" height="375" alt="Elephants at the Ark"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606838_c65187533b_o.jpg"
+      photo_width="600" thumb_width="200" title="Buffalo at the Ark" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740934946_f3e99feb9b_o.jpg"
+      photo_width="600" thumb_width="200" title="Buffalos at the Ark" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119477_98156ea6e6_o.jpg"
+      photo_width="600" thumb_width="200" title="Elephants at the Ark" lightbox="Game Drives"
+  %}
 </div>
 
 At the Aberdares Country Club, near the Ark, we also saw some baboons, impalas, thomson's gazelles, and a peacock.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606758/in/album-72157710860887528/" title="peacock_at_aberdares_country_club"><img class="image" src="https://live.staticflickr.com/65535/48740606758_0d4c94d668_z.jpg" width="450" height="600" alt="Peacock at Aberdares Country Club"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935281/in/album-72157710860887528/" title="peacock_closeup"><img class="image" src="https://live.staticflickr.com/65535/48740935281_7ddbc09737_z.jpg" width="500" height="375" alt="Peacock closeup"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606758_718889f723_o.jpg"
+      photo_width="450" thumb_width="150" title="Peacock at Aberdares Country Club" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935281_69b63473b8_o.jpg"
+      photo_width="600" thumb_width="200" title="Peacock close-up at Aberdares Country Club" lightbox="Game Drives"
+  %}
 </div>
 
 Although there weren't many animals at the Ark, it was our first real chance to see some wildlife, and it was exciting, nevertheless.
@@ -59,14 +74,38 @@ Although there weren't many animals at the Ark, it was our first real chance to 
 Samburu is an area north of the equator, located in the center of Kenya. The land around here is dry and desert-like, with few bushes and trees. Here, we saw baboons, reticulated giraffes, oryxes, impalas, thomson's gazelles, elephants, dik diks, ostriches, grevy's zebras, grant's gazelles (what our safari truck called "diaper butts," and see why [here](https://en.wikipedia.org/wiki/Grant%27s_gazelle)), and even a lioness resting in some bushes.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606393/in/album-72157710860887528/" title="baboon_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48740606393_eb129515d5_z.jpg" width="500" height="375" alt="Baboons at Samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606453/in/album-72157710860887528/" title="elephant_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48740606453_8d93d2912b_z.jpg" width="500" height="375" alt="Elephant at Samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119692/in/album-72157710860887528/" title="oryx_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48741119692_d885434f05_z.jpg" width="500" height="375" alt="Oryx at Samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935066/in/album-72157710860887528/" title="giraffe_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48740935066_007b4ee605_z.jpg" width="500" height="375" alt="Reticulated giraffes at Samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606638/in/album-72157710860887528/" title="impala_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48740606638_be9de360af_z.jpg" width="500" height="375" alt="Impalas at Samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606678/in/album-72157710860887528/" title="lion_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48740606678_ea278d8001_z.jpg" width="500" height="375" alt="lion_at_samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119697/in/album-72157710860887528/" title="ostrich_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48741119697_9c6f2a9382_z.jpg" width="500" height="375" alt="Male ostrich at Samburu"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119832/in/album-72157710860887528/" title="zebra_at_samburu"><img class="image" src="https://live.staticflickr.com/65535/48741119832_c5c568a998_z.jpg" width="500" height="375" alt="Zebra at Samburu"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606393_4f24904b75_o.jpg"
+      photo_width="600" thumb_width="200" title="Baboons at Samburu" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606453_02c1dcf73c_o.jpg"
+      photo_width="600" thumb_width="200" title="Elephant at Samburu" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119692_f8d37d4a98_o.jpg"
+      photo_width="600" thumb_width="200" title="Oryx at Samburu" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935066_7e21df8970_o.jpg"
+      photo_width="600" thumb_width="200" title="Reticulated giraffes at Samburu" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606638_752252d3bd_o.jpg"
+      photo_width="600" thumb_width="200" title="Impala at Samburu" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606678_6d9f3482a6_o.jpg"
+      photo_width="600" thumb_width="200" title="Lioness at Samburu (look closely)" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119697_5b99e26766_o.jpg"
+      photo_width="726000" thumb_width="200" title="Ostrich at Samburu" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119832_225ebe076d_o.jpg"
+      photo_width="600" thumb_width="200" title="Zebras at Samburu" lightbox="Game Drives"
+  %}
 </div>
 
 The incredible thing is that, on these safaris, the animals will come right up to the safari truck, as long as the truck is quiet, still, and patient. There were moments where the elephants were passing right by the truck.
@@ -78,9 +117,18 @@ Ol Pejeta is located in central Kenya, just straight north of Nairobi. The game 
 We managed to visit the Chimpanzee and Rhinoceros conservancies while we were there, and we managed to actually see chimpanzees interacting with each other (although they were lazily just lying around). We also had the unique opportunity to feed one of the black rhinos, a blind rhino named Baraka.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119427/in/album-72157710860887528/" title="chimp_at_ol_pejeta"><img class="image" src="https://live.staticflickr.com/65535/48741119427_ecb6585700_z.jpg" width="500" height="375" alt="Chimpanzee at Ol Pejeta Conservancy"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119722/in/album-72157710860887528/" title="rhino_at_ol_pejeta"><img class="image" src="https://live.staticflickr.com/65535/48741119722_d4de18f940_z.jpg" width="500" height="375" alt="Baraka, black rhino, at Ol Pejeta Conservancy"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606828/in/album-72157710860887528/" title="rhino_feeding_at_ol_pejeta"><img class="image" src="https://live.staticflickr.com/65535/48740606828_6d0a3a9f82_z.jpg" width="450" height="600" alt="Baraka feeding at Ol Pejeta Conservancy"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119427_950e08953a_o.jpg"
+      photo_width="600" thumb_width="200" title="Chimpanzee at Ol Pejeta" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119722_6ea09cfa61_o.jpg"
+      photo_width="600" thumb_width="200" title="Rhino at Ol Pejeta... and we got to pet it!" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606828_4cca69618e_o.jpg"
+      photo_width="450" thumb_width="150" title="Rhino feeding at Ol Pejeta" lightbox="Game Drives"
+  %}
 </div>
 
 We didn't see very many animals on the actual Ol Pejeta game drive, but we did see a dust tornado, and a storm settling in. It also rained while we were out driving, so we enjoyed the drop in temperature and playing [_Africa_ by Toto](https://www.youtube.com/watch?v=FTQbiNvZqaY) on our phones.
@@ -96,7 +144,10 @@ Lake Naivasha is a small lake just to the west of Nairobi. While there, we got t
 The resort where we stayed is famous for having hippos come graze on the grass right by the cabins, but we didn't see any hippos that night. We did manage to see some waterbucks grazing, but that was about it.
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935336/in/album-72157710860887528/" title="waterbucks_near_lake_naivasha"><img class="image" src="https://live.staticflickr.com/65535/48740935336_d67bcb8028_z.jpg" width="450" height="600" alt="Waterbucks near Lake Naivasha"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935336_73f8a59ae8_o.jpg"
+      photo_width="450" thumb_width="150" title="Waterbucks near Lake Naivasha" lightbox="Game Drives"
+  %}
 </div>
 
 ### Maasai Mara
@@ -108,21 +159,66 @@ Because of the time of year we went, and the location, we managed to see thousan
 Although I wish I could attach all of the pictures we have from the Maasai Mara, I honestly can't... there's too many incredible ones. Intead, I'll have to add some of my favorites:
 
 <div class="text-center">
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740934961/in/album-72157710860887528/" title="cheetah_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740934961_5e3588686e_z.jpg" width="500" height="375" alt="Cheetah at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935001/in/album-72157710860887528/" title="elephants_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935001_2f1da4cda5_z.jpg" width="500" height="375" alt="Elephants at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119482/in/album-72157710860887528/" title="elephants_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48741119482_e721e76543_z.jpg" width="500" height="375" alt="Elephants at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119542/in/album-72157710860887528/" title="giraffe_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48741119542_49f874fdf2_z.jpg" width="500" height="375" alt="Giraffe at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119572/in/album-72157710860887528/" title="giraffe_profile_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48741119572_4384b8dc6b_z.jpg" width="500" height="375" alt="Giraffe at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935081/in/album-72157710860887528/" title="hippo_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935081_8aaf5759f3_z.jpg" width="500" height="375" alt="Lounging hippos at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935106/in/album-72157710860887528/" title="hippo_swimming_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935106_12814e2f60_z.jpg" width="500" height="375" alt="Swimming hippo at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119617/in/album-72157710860887528/" title="hyenas_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48741119617_e81e0690b3_z.jpg" width="500" height="375" alt="Hyengas at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935151/in/album-72157710860887528/" title="leopard_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935151_fb665b6280_z.jpg" width="500" height="375" alt="Sleeping leopard at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740606698/in/album-72157710860887528/" title="lions_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740606698_5f5e777d93_z.jpg" width="500" height="375" alt="Lions at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935211/in/album-72157710860887528/" title="lion_yawning_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935211_dde4f02937_z.jpg" width="500" height="375" alt="Yawning lion at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935321/in/album-72157710860887528/" title="warthogs_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935321_599710837a_z.jpg" width="500" height="375" alt="Warthogs at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119787/in/album-72157710860887528/" title="wildebeest_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48741119787_fbe95cb73d_z.jpg" width="500" height="375" alt="Wildebeest at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48740935386/in/album-72157710860887528/" title="wildebeests_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48740935386_2d23d41760_z.jpg" width="500" height="375" alt="Wildebeests at Maasai Mara"></a>
-  <a data-flickr-embed="true" href="https://www.flickr.com/photos/184539266@N08/48741119842/in/album-72157710860887528/" title="zebras_at_maasai_mara"><img class="image" src="https://live.staticflickr.com/65535/48741119842_bb49aaace2_z.jpg" width="500" height="375" alt="Zebras at Maasai Mara"></a>
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740934961_f96f3dd557_o.jpg"
+      photo_width="600" thumb_width="200" title="Cheetah at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935001_ed2ef1a21f_o.jpg"
+      photo_width="600" thumb_width="200" title="Elephants at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119482_2a65f2332a_o.jpg"
+      photo_width="600" thumb_width="200" title="Momma elephant with baby at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119542_20ff32c710_o.jpg"
+      photo_width="600" thumb_width="200" title="Giraffe at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119572_75b99d2f3e_o.jpg"
+      photo_width="600" thumb_width="200" title="Giraffe headshot at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935081_640dc843a8_o.jpg"
+      photo_width="600" thumb_width="200" title="Hippo at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935106_67389659e4_o.jpg"
+      photo_width="600" thumb_width="200" title="Swimming hippo at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119617_67389659e4_o.jpg"
+      photo_width="450" thumb_width="200" title="Hyenas at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935151_cedbc943a3_o.jpg"
+      photo_width="600" thumb_width="200" title="Leopard laying around at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740606698_6ae7e8c66d_o.jpg"
+      photo_width="600" thumb_width="200" title="Lions at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935211_3504edbc65_o.jpg"
+      photo_width="600" thumb_width="200" title="Yawning lion at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935321_f29e95c343_o.jpg"
+      photo_width="600" thumb_width="200" title="Warthogs at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119787_f547fdb8b4_o.jpg"
+      photo_width="600" thumb_width="200" title="Wildebeests at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48740935386_f3d51837f8_o.jpg"
+      photo_width="550" thumb_width="200" title="Walking wildebeests at Maasai Mara" lightbox="Game Drives"
+  %}
+  {% include elements/photo.html
+      url="https://live.staticflickr.com/65535/48741119842_aa42e45571_o.jpg"
+      photo_width="600" thumb_width="200" title="Zebras at Maasai Mara" lightbox="Game Drives"
+  %}
 </div>
 
 ## Conclusion

--- a/_includes/elements/photo.html
+++ b/_includes/elements/photo.html
@@ -1,3 +1,3 @@
-<a href="{{ include.url }}" width="{{ include.photo_width }}" title="{{ include.title }}" data-lightbox="{{ include.lightbox }}">
+<a href="{{ include.url }}" title="{{ include.title }}" data-lightbox="{{ include.lightbox }}">
   <img class="image" src="{{ include.url }}" width="{{ include.thumb_width }}" alt="{{ include.title }}">
 </a>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -6,6 +6,9 @@ layout: default
 
 <div class="page-body">
   {{ content }}
+  {% if content != blank %}
+    <br><br>
+  {% endif %}
   {% include blog/posts-list.html %}
 </div>
 

--- a/_legos/box.md
+++ b/_legos/box.md
@@ -14,22 +14,22 @@ NOTE: the LDD piece list numbers can sometimes be out of sync with what's in the
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947517557_17d59cec8a_k.jpg"
-      photo_width="2048" thumb_width="200" title="Box with squares on lid closed" lightbox="Box"
+      thumb_width="200" title="Box with squares on lid closed" lightbox="Box"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947231231_f1210a975c_k.jpg"
-      photo_width="2048" thumb_width="200" title="Box with squares on lid open" lightbox="Box"
+      thumb_width="200" title="Box with squares on lid open" lightbox="Box"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947517287_14879a7720_k.jpg"
-      photo_width="2048" thumb_width="200" title="Grey and black box closed" lightbox="Box"
+      thumb_width="200" title="Grey and black box closed" lightbox="Box"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49946728308_34ba273aa0_k.jpg"
-      photo_width="2048" thumb_width="200" title="Grey and black box closed from back" lightbox="Box"
+      thumb_width="200" title="Grey and black box closed from back" lightbox="Box"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947516887_e9bea792d3_k.jpg"
-      photo_width="2048" thumb_width="200" title="Grey and black box opened" lightbox="Box"
+      thumb_width="200" title="Grey and black box opened" lightbox="Box"
   %}
 </div>

--- a/_legos/car.md
+++ b/_legos/car.md
@@ -16,18 +16,18 @@ Featured in the photographs are two minifigures I've designed (who I've named Ta
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985840352_9032841264_b.jpg"
-      photo_width="2048" thumb_width="200" title="Car front" lightbox="Car"
+      thumb_width="200" title="Car front" lightbox="Car"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985585081_8a33a16dee_b.jpg"
-      photo_width="2048" thumb_width="200" title="Car back" lightbox="Car"
+      thumb_width="200" title="Car back" lightbox="Car"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985840327_da44a85b5d_b.jpg"
-      photo_width="2048" thumb_width="200" title="Car with driver door open" lightbox="Car"
+      thumb_width="200" title="Car with driver door open" lightbox="Car"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985065258_fdd7b8c519_b.jpg"
-      photo_width="2048" thumb_width="200" title="Car top view" lightbox="Car"
+      thumb_width="200" title="Car top view" lightbox="Car"
   %}
 </div>

--- a/_legos/disney-princess-storybooks.md
+++ b/_legos/disney-princess-storybooks.md
@@ -21,78 +21,78 @@ Here are their links:
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073767857_581d46f6ba_b.jpg"
-      photo_width="2048" thumb_width="265" title="Storybooks all facing front" lightbox="Disney Storybook Adventures"
+      thumb_width="265" title="Storybooks all facing front" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953473_ced1aba3fe_b.jpg"
-      photo_width="2048" thumb_width="200" title="Storybooks from top" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Storybooks from top" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953418_f5729685e4_b.jpg"
-      photo_width="2048" thumb_width="200" title="Storybooks at diagonal" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Storybooks at diagonal" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073767592_a7b5c7fa25_b.jpg"
-      photo_width="2048" thumb_width="200" title="Storybooks from the back" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Storybooks from the back" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520906_15d6211ab4_b.jpg"
-      photo_width="2048" thumb_width="200" title="Storybooks from the side" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Storybooks from the side" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073768857_d40e8f5e21_b.jpg"
-      photo_width="2048" thumb_width="200" title="Beauty and the Beast courtyard" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Beauty and the Beast courtyard" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073522166_892972f23d_b.jpg"
-      photo_width="2048" thumb_width="200" title="Beauty and the Beast ballroom" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Beauty and the Beast ballroom" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073766857_7571423bec_b.jpg"
-      photo_width="2048" thumb_width="200" title="Beauty and the Beast top" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Beauty and the Beast top" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073768732_dc58b62142_b.jpg"
-      photo_width="2048" thumb_width="200" title="The Little Mermaid beach" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="The Little Mermaid beach" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073522061_963a5ef075_b.jpg"
-      photo_width="2048" thumb_width="200" title="The Little Mermaid under the sea" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="The Little Mermaid under the sea" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073766797_6d43b19eef_b.jpg"
-      photo_width="2048" thumb_width="200" title="The Little Mermaid top" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="The Little Mermaid top" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520846_c68a00f9b4_b.jpg"
-      photo_width="2048" thumb_width="200" title="Frozen indoors close-up" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Frozen indoors close-up" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953068_3b38fb07a0_b.jpg"
-      photo_width="2048" thumb_width="200" title="Frozen indoors" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Frozen indoors" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520691_e54949b788_b.jpg"
-      photo_width="2048" thumb_width="200" title="Frozen outdoors" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Frozen outdoors" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520256_5f2be8156b_b.jpg"
-      photo_width="2048" thumb_width="200" title="Frozen top" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Frozen top" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520646_a176a34a3a_b.jpg"
-      photo_width="2048" thumb_width="200" title="Mulan at home" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Mulan at home" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520601_ae8e013d06_b.jpg"
-      photo_width="2048" thumb_width="200" title="Mulan at the army camp" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Mulan at the army camp" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073766997_8d946b0458_b.jpg"
-      photo_width="2048" thumb_width="200" title="Mulan at the army camp straight ahead" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Mulan at the army camp straight ahead" lightbox="Disney Storybook Adventures"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520461_d14e47fdb4_b.jpg"
-      photo_width="2048" thumb_width="200" title="Mulan top" lightbox="Disney Storybook Adventures"
+      thumb_width="200" title="Mulan top" lightbox="Disney Storybook Adventures"
   %}
 </div>

--- a/_legos/diving-yacht.md
+++ b/_legos/diving-yacht.md
@@ -10,18 +10,18 @@ Here's a link to the set: [Diving Yacht (60221)](https://www.lego.com/en-us/prod
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49977811291_ddb1464984_k.jpg"
-      photo_width="2048" thumb_width="200" title="Yacht with cover" lightbox="Diving Yacht"
+      thumb_width="200" title="Yacht with cover" lightbox="Diving Yacht"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978073062_941dcf47c0_k.jpg"
-      photo_width="2048" thumb_width="200" title="Scuba diver underwater" lightbox="Diving Yacht"
+      thumb_width="200" title="Scuba diver underwater" lightbox="Diving Yacht"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49977291103_ef9e709552_k.jpg"
-      photo_width="1536" thumb_width="200" title="Yacht with top off" lightbox="Diving Yacht"
+      thumb_width="200" title="Yacht with top off" lightbox="Diving Yacht"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978072787_1a3a6f42eb_k.jpg"
-      photo_width="2048" thumb_width="200" title="Two scuba divers underwater" lightbox="Diving Yacht"
+      thumb_width="200" title="Two scuba divers underwater" lightbox="Diving Yacht"
   %}
 </div>

--- a/_legos/dorm-room.md
+++ b/_legos/dorm-room.md
@@ -18,22 +18,22 @@ NOTES: the LDD piece list numbers can sometimes be out of sync with what's in th
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050573101_fb17cb502a_k.jpg"
-      photo_width="2048" thumb_width="200" title="Dorm Room top facing napping minifigure" lightbox="Dorm Room"
+      thumb_width="200" title="Dorm Room top facing napping minifigure" lightbox="Dorm Room"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050826537_4d42eae374_k.jpg"
-      photo_width="2048" thumb_width="200" title="Dorm Room top facing studying minifigure" lightbox="Dorm Room"
+      thumb_width="200" title="Dorm Room top facing studying minifigure" lightbox="Dorm Room"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050572856_c7703277aa_k.jpg"
-      photo_width="2048" thumb_width="200" title="Dorm Room top facing door" lightbox="Dorm Room"
+      thumb_width="200" title="Dorm Room top facing door" lightbox="Dorm Room"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050572721_96905699ca_k.jpg"
-      photo_width="2048" thumb_width="200" title="Dorm Room looking through door" lightbox="Dorm Room"
+      thumb_width="200" title="Dorm Room looking through door" lightbox="Dorm Room"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050574776_402215300c_k.jpg"
-      photo_width="2048" thumb_width="200" title="Dorm Room top facing windows" lightbox="Dorm Room"
+      thumb_width="200" title="Dorm Room top facing windows" lightbox="Dorm Room"
   %}
 </div>

--- a/_legos/dots-picture-frame.md
+++ b/_legos/dots-picture-frame.md
@@ -12,14 +12,14 @@ Also featured in the last photograph is my personal minifigure that my coworker 
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978623252_0e93eaca6d_k.jpg"
-      photo_width="2048" thumb_width="200" title="DOTS frame design 1 forward" lightbox="DOTS frame"
+      thumb_width="200" title="DOTS frame design 1 forward" lightbox="DOTS frame"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978622887_5d44c13836_k.jpg"
-      photo_width="1536" thumb_width="200" title="DOTS frame design 1 tilted" lightbox="DOTS frame"
+      thumb_width="200" title="DOTS frame design 1 tilted" lightbox="DOTS frame"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978362791_4b9eee62c1_k.jpg"
-      photo_width="2048" thumb_width="200" title="DOTS frame and minifigure" lightbox="DOTS frame"
+      thumb_width="200" title="DOTS frame and minifigure" lightbox="DOTS frame"
   %}
 </div>

--- a/_legos/fairground.md
+++ b/_legos/fairground.md
@@ -16,18 +16,18 @@ Here's a link to the set: [People Pack – Fun Fair (60234)](https://www.lego.co
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050571391_c25a153b4f_k.jpg"
-      photo_width="2048" thumb_width="200" title="Fairground front" lightbox="Fairground"
+      thumb_width="200" title="Fairground front" lightbox="Fairground"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050003703_039321bf98_k.jpg"
-      photo_width="2048" thumb_width="200" title="Fairground back" lightbox="Fairground"
+      thumb_width="200" title="Fairground back" lightbox="Fairground"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050573421_9b12a93862_k.jpg"
-      photo_width="2048" thumb_width="200" title="Fairground side" lightbox="Fairground"
+      thumb_width="200" title="Fairground side" lightbox="Fairground"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050009548_b31c09f6d8_k.jpg"
-      photo_width="2048" thumb_width="200" title="Fairground top" lightbox="Fairground"
+      thumb_width="200" title="Fairground top" lightbox="Fairground"
   %}
 </div>

--- a/_legos/flower-display.md
+++ b/_legos/flower-display.md
@@ -12,14 +12,14 @@ Here's a link to the set: [Flower Display (40187)](https://www.lego.com/en-us/pr
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072954358_4a7a32c1bd_k.jpg"
-      photo_width="2048" thumb_width="200" title="Flower Display side by side" lightbox="Flower Display"
+      thumb_width="200" title="Flower Display side by side" lightbox="Flower Display"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521936_c0875a095f_k.jpg"
-      photo_width="2048" thumb_width="200" title="Flower Display top" lightbox="Flower Display"
+      thumb_width="200" title="Flower Display top" lightbox="Flower Display"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521861_e393dd2977_k.jpg"
-      photo_width="2048" thumb_width="200" title="Flower Display showcasing depth" lightbox="Flower Display"
+      thumb_width="200" title="Flower Display showcasing depth" lightbox="Flower Display"
   %}
 </div>

--- a/_legos/helicopter-adventure.md
+++ b/_legos/helicopter-adventure.md
@@ -10,26 +10,26 @@ Here's a link to the set: [Helicopter Adventure (31092)](https://www.lego.com/en
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49977843728_9fc00bb86e_k.jpg"
-      photo_width="2048" thumb_width="150" title="Helicopter front" lightbox="LEGO 3-in-1 Creator085"
+      thumb_width="150" title="Helicopter front" lightbox="LEGO 3-in-1 Creator085"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978363246_77d3d3a753_k.jpg"
-      photo_width="2048" thumb_width="150" title="Helicopter back" lightbox="LEGO 3-in-1 Creator085"
+      thumb_width="150" title="Helicopter back" lightbox="LEGO 3-in-1 Creator085"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978363141_99b96ba922_k.jpg"
-      photo_width="2048" thumb_width="150" title="Steamboat front" lightbox="LEGO 3-in-1 Creator085"
+      thumb_width="150" title="Steamboat front" lightbox="LEGO 3-in-1 Creator085"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978362646_a50bd0f186_k.jpg"
-      photo_width="1536" thumb_width="150" title="Steamboat back" lightbox="LEGO 3-in-1 Creator085"
+      thumb_width="150" title="Steamboat back" lightbox="LEGO 3-in-1 Creator085"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978623487_2fa36eec74_k.jpg"
-      photo_width="2048" thumb_width="150" title="Plane front" lightbox="LEGO 3-in-1 Creator085"
+      thumb_width="150" title="Plane front" lightbox="LEGO 3-in-1 Creator085"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978362526_df871ac79c_k.jpg"
-      photo_width="1536" thumb_width="150" title="Plane back" lightbox="LEGO 3-in-1 Creator085"
+      thumb_width="150" title="Plane back" lightbox="LEGO 3-in-1 Creator085"
   %}
 </div>

--- a/_legos/raft.md
+++ b/_legos/raft.md
@@ -10,18 +10,18 @@ The minifigures were designed by myself, and I specifically ordered top, bottom,
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953968_e15523675c_k.jpg"
-      photo_width="2048" thumb_width="200" title="Raft Front" lightbox="Raft"
+      thumb_width="200" title="Raft Front" lightbox="Raft"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953903_4a5356bea5_k.jpg"
-      photo_width="2048" thumb_width="200" title="Raft Back" lightbox="Raft"
+      thumb_width="200" title="Raft Back" lightbox="Raft"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521516_072e24ab86_k.jpg"
-      photo_width="2048" thumb_width="200" title="Raft hooked on 'dock'" lightbox="Raft"
+      thumb_width="200" title="Raft hooked on 'dock'" lightbox="Raft"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953783_a32953e624_k.jpg"
-      photo_width="2048" thumb_width="200" title="Raft top" lightbox="Raft"
+      thumb_width="200" title="Raft top" lightbox="Raft"
   %}
 </div>

--- a/_legos/unikitty-cart.md
+++ b/_legos/unikitty-cart.md
@@ -12,14 +12,14 @@ Here's a link to the set: [Unikitty Roller Coaster Wagon](https://www.lego.com/e
 <div class="text-center">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072954158_32c27268d2_k.jpg"
-      photo_width="2048" thumb_width="200" title="Cart Front" lightbox="Unikitty Cart"
+      thumb_width="200" title="Cart Front" lightbox="Unikitty Cart"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072954108_abe06bd835_k.jpg"
-      photo_width="2048" thumb_width="200" title="Cart Back" lightbox="Unikitty Cart"
+      thumb_width="200" title="Cart Back" lightbox="Unikitty Cart"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521661_37680a69e1_k.jpg"
-      photo_width="2048" thumb_width="200" title="Cart with piece ejected out" lightbox="Unikitty Cart"
+      thumb_width="200" title="Cart with piece ejected out" lightbox="Unikitty Cart"
   %}
 </div>

--- a/pages/blog/skimp-and-splurge.md
+++ b/pages/blog/skimp-and-splurge.md
@@ -10,3 +10,5 @@ pagination:
 ---
 
 This is a collection of posts that are all inspired from an original "blog" post that I wrote in December of 2016, titled _Skimp and Splurge: The Art of Saving Money_. I decided to turn this singular blog post into a group of posts when I decided to do a re-evaluation of the items in that post. Going forward, I also hope to conduct interviews with people in my life to get their opinions on these items as well.
+
+<br><br>

--- a/pages/blog/skimp-and-splurge.md
+++ b/pages/blog/skimp-and-splurge.md
@@ -10,5 +10,3 @@ pagination:
 ---
 
 This is a collection of posts that are all inspired from an original "blog" post that I wrote in December of 2016, titled _Skimp and Splurge: The Art of Saving Money_. I decided to turn this singular blog post into a group of posts when I decided to do a re-evaluation of the items in that post. Going forward, I also hope to conduct interviews with people in my life to get their opinions on these items as well.
-
-<br><br>

--- a/pages/blog/welcome-to-kenya.md
+++ b/pages/blog/welcome-to-kenya.md
@@ -12,5 +12,3 @@ pagination:
 A complilation of five blog posts revolving around my trip to Kenya in the summer of 2019. You can tell I will remember Kenya with fond memories.
 
 I'd like to extend a huge "thank you" to my fellow adventurers: Kristen Correa, Evelyn Kodman, Jennifer Hruska, Impreet Aulakh, Kristal Seckinger, Heather Hubbard, Audrey Boss, Sarah Hawkins, Tami McBride, and Linda McWilliams, for the use of their incredible photos in these posts.
-
-<br><br>

--- a/pages/blog/welcome-to-kenya.md
+++ b/pages/blog/welcome-to-kenya.md
@@ -12,3 +12,5 @@ pagination:
 A complilation of five blog posts revolving around my trip to Kenya in the summer of 2019. You can tell I will remember Kenya with fond memories.
 
 I'd like to extend a huge "thank you" to my fellow adventurers: Kristen Correa, Evelyn Kodman, Jennifer Hruska, Impreet Aulakh, Kristal Seckinger, Heather Hubbard, Audrey Boss, Sarah Hawkins, Tami McBride, and Linda McWilliams, for the use of their incredible photos in these posts.
+
+<br><br>


### PR DESCRIPTION
## Changes

* Change blog posts to use photo modals instead of directly linking to Flickr
* Add a couple of newlines between blog post summaries and list of blog posts (if there's a summary at all)
* Remove the `photo_width` from the element include because the code will use the width that Flickr provides with the URL; besides, don't we want it to be the biggest width as possible/will fit on the user's screen?
* Update the PR Scheduler format from `DD-MM-YYYYTHH:MM` to `YYYY-MM-DD HH:MM` because the scheduler now accepts that

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
