### PR TITLE
Adjust URL in navbar and tags list

### DIFF
--- a/_blog_posts/switching-from-kramdown-to-commonmark.md
+++ b/_blog_posts/switching-from-kramdown-to-commonmark.md
@@ -162,7 +162,7 @@ becomes this:
   {% endfor %}{% endraw %}
 ```
 
-It certainly doesn't look as pretty... I always prefer to have my HTML indented properly. But compromising and being willing to move my lines around is worth a much faster build time.-->
+It certainly doesn't look as pretty... I always prefer to have my HTML indented properly. But compromising and being willing to move my lines around is worth a much faster build time. -->
 
 After I was satisfied with my changes, I willingly merged my pull request and deployed away. A little while later, I noticed a few other key pieces I missed.
 

--- a/_blog_posts/switching-from-kramdown-to-commonmark.md
+++ b/_blog_posts/switching-from-kramdown-to-commonmark.md
@@ -162,7 +162,7 @@ becomes this:
   {% endfor %}{% endraw %}
 ```
 
-It certainly doesn't look as pretty... I always prefer to have my HTML indented properly. But compromising and being willing to move my lines around is worth a much faster build time. -->
+It certainly doesn't look as pretty... I always prefer to have my HTML indented properly. But compromising and being willing to move my lines around is worth a much faster build time.-->
 
 After I was satisfied with my changes, I willingly merged my pull request and deployed away. A little while later, I noticed a few other key pieces I missed.
 
@@ -215,3 +215,7 @@ Most of these changes only took a few of hours, and in my opinion, they were wel
 * [wordpress.org: heading with anchor links are covered up by top of page header](https://wordpress.org/support/topic/heading-with-anchor-links-are-covered-up-by-top-of-page-header/)
 * [github.com: jekyll/jekyll-commonmark](https://github.com/jekyll/jekyll-commonmark)
 * [github.com: gjtorikian/commonmarker](https://github.com/gjtorikian/commonmarker)
+
+---
+
+Update: Since publishing this blog post, I've actually added back in almost every usage of `markdownify` that I had previously removed. The only place where it absolutely does not work is when rendering individual blog posts. It's possible `markdownify` wasn't the source of what was broken, but was just masking other issues I resolved around the same time.

--- a/_includes/blog/post_summary.html
+++ b/_includes/blog/post_summary.html
@@ -1,4 +1,4 @@
-{% assign post_url = post.url | downcase | replace: ".html", "" %}
+{% assign post_url = post.url | downcase %}
 {% if post.subtitle %}
   {% if page.pagination.title == "Blog" %}
     {% assign short_title = post.title | append: " — " | append: post.subtitle %}

--- a/_includes/site_navigation.html
+++ b/_includes/site_navigation.html
@@ -22,7 +22,7 @@
 
         {% for node in sorted_pages %}
           {% unless node.autogen == "jekyll-paginate-v2" %}
-            {% assign navigation_url = node.url | remove: "/index.html" %}
+            {% assign navigation_url = node.url | remove: "index.html" %}
 
             {% if page.url contains navigation_url %}
               {% assign active = "active" %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -21,10 +21,7 @@ layout: default
 
     <!-- List of blog posts -->
     <div class="page-body">
-      {{ content }}
-      {% if content != blank %}
-        <br><br>
-      {% endif %}
+      {{ content | markdownify }}
       {% for post in paginator.posts %}
         {% include blog/post_summary.html %}
       {% endfor %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -16,7 +16,7 @@ layout: default
 
     <!-- Tagline and URL buttons -->
     <div class="col-md text-center mt-5">
-      {{ content }}
+      {{ content | markdownify }}
 
       <div class="mt-5" style="padding-bottom:50px;">
         <h3 style="font-weight: bold; padding-bottom: 25px;">Connect with me:</h4>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,5 +7,5 @@ layout: default
 </div>
 
 <div class="page-body">
-  {{ content }}
+  {{ content | markdownify }}
 </div>

--- a/pages/about-me.md
+++ b/pages/about-me.md
@@ -5,11 +5,11 @@ order: 1
 permalink: /about-me/
 ---
 
-Since graduating from the [University of Minnesota, Morris (UMM)](https://morris.umn.edu/) with a Bachelor of Arts in [Computer Science](https://academics.morris.umn.edu/computer-science), my entire career has been spent on the Operations side of DevOps. But I dabble in website development in Ruby on Rails and Jekyll/Liquid. For a more detailed version of my experience, please visit my [LinkedIn](https://linkedin.com/in/emmasax4).
+Since graduating from the [University of Minnesota, Morris (UMM)](https://morris.umn.edu/) with a Bachelor of Arts in [Computer Science](https://academics.morris.umn.edu/computer-science), my entire career has been spent on the Operations side of DevOps. But I dabble in website development in Ruby on Rails and Jekyll/Liquid. For a more information on my work experience, please visit my [LinkedIn](https://linkedin.com/in/emmasax4).
 
 ## Tools, Frameworks, & Languages
 
-Ruby, Ruby on Rails, Bash, Git, GitHub API, AWS API, HTML/CSS, Yaml/JSON, Chef, Amazon Web Services, Kubernetes/EKS, New Relic, Datadog, Splunk, Jekyll/Liquid
+Ruby, Ruby on Rails, Bash, Git, GitHub API, AWS-SDK, HTML/CSS, Yaml/JSON, Chef, Amazon Web Services, Kubernetes/EKS, New Relic, Datadog, Splunk, Liquid/Jekyll
 
 ## Operating Systems
 
@@ -17,7 +17,7 @@ OS X, Linux
 
 ## Other
 
-Self-motivated, leadership skills, detail-oriented, problem solving skills, pair programming, agile methodologies, communication skills, collaboration, enthusiasm, strong work-ethic
+Self-motivated, leadership skills, detail-oriented, problem-solving skills, pair programming, agile methodologies, communication skills, collaboration, enthusiasm, strong work-ethic
 
 ## Experience
 

--- a/pages/about-me.md
+++ b/pages/about-me.md
@@ -17,7 +17,7 @@ OS X, Linux
 
 ## Other
 
-Self-motivated, leadership skills, detail-oriented, problem-solving skills, pair programming, agile methodologies, communication skills, collaboration, enthusiasm, strong work-ethic
+Self-motivated, leadership skills, detail-oriented, problem solving skills, pair programming, agile methodologies, communication skills, collaboration, enthusiasm, strong work-ethic
 
 ## Experience
 


### PR DESCRIPTION
## Changes

* Update about me page
* Simplify the internal smart-URLs
* Add back in some `markdownify`s (not all of them, for some reason using `markdownify` when rendering individual blog posts still breaks)
* Adding a note about the `markdownify`s in the kramdown to CommonMark blog post