### PR TITLE
No need to specify _site with lots of characters

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -32,7 +32,7 @@ jobs:
       run: bundle config set path "vendor/bundle" && bundle install
 
     - name: Jekyll Build
-      run: JEKYLL_ENV=production bundle exec jekyll build --destination ./_site/
+      run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
     - name: HTML Proofer
       run: bash scripts/html_proofer.sh || echo ""

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -32,7 +32,7 @@ jobs:
       run: bundle config set path "vendor/bundle" && bundle install
 
     - name: Jekyll Build
-      run: JEKYLL_ENV=production bundle exec jekyll build --destination ./_site/
+      run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
     - name: HTML Proofer
       run: bash scripts/html_proofer.sh || echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       run: bundle config set path "vendor/bundle" && bundle install
 
     - name: Jekyll Build
-      run: JEKYLL_ENV=production bundle exec jekyll build --destination ./_site/
+      run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
     - name: HTML Proofer
       run: bash scripts/html_proofer.sh || echo ""

--- a/_blog_posts/why-i-switched-from-circleci-to-github-actions.md
+++ b/_blog_posts/why-i-switched-from-circleci-to-github-actions.md
@@ -116,11 +116,11 @@ The next few steps are to set up Bundler, install gems, and build the site. I'll
 
 # build the site
 - name: Jekyll Build
-  run: JEKYLL_ENV=production bundle exec jekyll build --destination ./_site/
+  run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
 # run HTML proofer
 - name: HTML Proofer
-  run: bundle exec htmlproofer --assume-extension --allow-hash-href --internal-domains /emmasax4.info/ --only_4xx ./_site/{% endraw %}
+  run: bundle exec htmlproofer --assume-extension --allow-hash-href --internal-domains /emmasax4.info/ --only_4xx _site{% endraw %}
 ```
 
 Bam! Not too shabby. This now looks _very_ familiar to CircleCI.

--- a/_blog_posts/why-i-switched-from-travis-ci-to-circleci.md
+++ b/_blog_posts/why-i-switched-from-travis-ci-to-circleci.md
@@ -203,7 +203,7 @@ commands:
     steps:
     - run:
         name: Jekyll Build
-        command: {% raw %}JEKYLL_ENV=production bundle exec jekyll build --destination ./_site/{% endraw %}
+        command: {% raw %}JEKYLL_ENV=production bundle exec jekyll build --destination _site{% endraw %}
   html_proofer:
     steps:
     - run:
@@ -232,7 +232,7 @@ gem install bundler
     --assume-extension \
     --allow-hash-href \
     --internal-domains /emmasax4.info/ \
-    ./_site/{% endraw %}
+    _site{% endraw %}
 ```
 
 <div id="anchor">
@@ -352,9 +352,9 @@ git pull origin gh-pages
 # Delete everything except the _site, .git, and .circleci directories
 find . -maxdepth 1 ! -name "_site" ! -name ".git" ! -name ".circleci" -exec rm -rf {} \;
 # Move the _site directory contents into the root directory
-mv ./_site/* .
+mv _site* .
 # Delete the _site directory, as it's now empty
-rm -R ./_site/
+rm -R _site
 
 # Now make a deploy to the gh-pages branch and push!
 git add -fA

--- a/scripts/html_proofer.sh
+++ b/scripts/html_proofer.sh
@@ -5,7 +5,7 @@ bundle exec htmlproofer \
   --allow-hash-href \
   --internal-domains /emmasax4.info/ \
   --url_ignore /linkedin/,/getitwriteonline/,/sopalodges/,/maasaimara/ \
-  ./_site/
+  _site
 
 # https://www.sopalodges.com/lake-naivasha-sopa-resort/the-resort
 # https://getitwriteonline.com/articles/en-dashes-em-dashes/


### PR DESCRIPTION
## Changes

We can save some characters by typing `./_site/` as just `_site`. They're both directories in Yaml, and both pretty understandable. Having a bunch of extra slashes and dots just makes it harder to read.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
